### PR TITLE
feat(summary): provider + AsyncStorage + events

### DIFF
--- a/__tests__/summaryStylesStore.test.ts
+++ b/__tests__/summaryStylesStore.test.ts
@@ -1,0 +1,50 @@
+import { test, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  setStorage,
+  list,
+  create,
+  update,
+  remove,
+} from '../data/summaryStylesStore.ts';
+import type { StorageLike } from '../data/summaryStylesStore.ts';
+
+class MemoryStorage implements StorageLike {
+  private store: Record<string, string> = {};
+  async getItem(key: string): Promise<string | null> {
+    return this.store.hasOwnProperty(key) ? this.store[key] : null;
+  }
+  async setItem(key: string, value: string): Promise<void> {
+    this.store[key] = value;
+  }
+  async removeItem(key: string): Promise<void> {
+    delete this.store[key];
+  }
+}
+
+beforeEach(() => {
+  setStorage(new MemoryStorage());
+});
+
+test('create and list summary style', async () => {
+  const created = await create({ title: 'Title', subtitle: 'Sub', prompt: 'Prompt' });
+  const styles = await list();
+  assert.equal(styles.length, 1);
+  assert.equal(styles[0].id, created.id);
+});
+
+test('update summary style', async () => {
+  const created = await create({ title: 'Title', subtitle: 'Sub', prompt: 'Prompt' });
+  const updated = await update(created.id, { title: 'New Title' });
+  assert.ok(updated);
+  assert.equal(updated?.title, 'New Title');
+  const styles = await list();
+  assert.equal(styles[0].title, 'New Title');
+});
+
+test('remove summary style', async () => {
+  const created = await create({ title: 'Title', subtitle: 'Sub', prompt: 'Prompt' });
+  await remove(created.id);
+  const styles = await list();
+  assert.equal(styles.length, 0);
+});

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -2,16 +2,17 @@ import { useEffect } from 'react';
 import { Stack } from 'expo-router';
 import { StatusBar } from 'expo-status-bar';
 import { useFrameworkReady } from '@/hooks/useFrameworkReady';
+import { SummaryStylesProvider } from '@/context/SummaryStylesContext';
 
 export default function RootLayout() {
   useFrameworkReady();
 
   return (
-    <>
+    <SummaryStylesProvider>
       <Stack screenOptions={{ headerShown: false }}>
         <Stack.Screen name="+not-found" />
       </Stack>
       <StatusBar style="auto" />
-    </>
+    </SummaryStylesProvider>
   );
 }

--- a/context/SummaryStylesContext.tsx
+++ b/context/SummaryStylesContext.tsx
@@ -1,0 +1,103 @@
+import React, { createContext, useContext, useState, useEffect, useCallback, ReactNode } from 'react';
+import { SummaryStyle } from '@/types/summary';
+import { DEFAULT_SUMMARY_STYLES } from '@/data/summaryStylesDefaults';
+import {
+  summaryStylesEmitter,
+  list as listStyles,
+  hydrate as hydrateStyles,
+  create as createStyle,
+  update as updateStyle,
+  remove as removeStyle,
+} from '@/data/summaryStylesStore';
+
+interface SummaryStylesState {
+  styles: SummaryStyle[];
+  loading: boolean;
+  error?: string;
+}
+
+interface SummaryStylesContextValue {
+  state: SummaryStylesState;
+  list: () => Promise<SummaryStyle[]>;
+  hydrate: () => Promise<void>;
+  create: (style: Omit<SummaryStyle, 'id' | 'updatedAt'>) => Promise<SummaryStyle>;
+  update: (id: string, updates: Partial<Omit<SummaryStyle, 'id' | 'updatedAt'>>) => Promise<SummaryStyle | null>;
+  remove: (id: string) => Promise<void>;
+  emitter: typeof summaryStylesEmitter;
+}
+
+const SummaryStylesContext = createContext<SummaryStylesContextValue | undefined>(undefined);
+
+export function SummaryStylesProvider({ children }: { children: ReactNode }) {
+  const [state, setState] = useState<SummaryStylesState>({ styles: [], loading: true });
+
+  const hydrate = useCallback(async () => {
+    try {
+      setState(prev => ({ ...prev, loading: true, error: undefined }));
+      const styles = await hydrateStyles(DEFAULT_SUMMARY_STYLES);
+      setState({ styles, loading: false });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to load summary styles';
+      setState({ styles: [], loading: false, error: message });
+    }
+  }, []);
+
+  useEffect(() => {
+    hydrate();
+  }, [hydrate]);
+
+  useEffect(() => {
+    const handleChange = async () => {
+      const styles = await listStyles();
+      setState(prev => ({ ...prev, styles }));
+    };
+    summaryStylesEmitter.on('summaryStyles/changed', handleChange);
+    return () => {
+      summaryStylesEmitter.off('summaryStyles/changed', handleChange);
+    };
+  }, []);
+
+  const list = useCallback(async () => {
+    const styles = await listStyles();
+    setState(prev => ({ ...prev, styles }));
+    return styles;
+  }, []);
+
+  const create = useCallback(async (style: Omit<SummaryStyle, 'id' | 'updatedAt'>) => {
+    const newStyle = await createStyle(style);
+    return newStyle;
+  }, []);
+
+  const update = useCallback(async (id: string, updates: Partial<Omit<SummaryStyle, 'id' | 'updatedAt'>>) => {
+    const updated = await updateStyle(id, updates);
+    return updated;
+  }, []);
+
+  const remove = useCallback(async (id: string) => {
+    await removeStyle(id);
+  }, []);
+
+  const value: SummaryStylesContextValue = {
+    state,
+    list,
+    hydrate,
+    create,
+    update,
+    remove,
+    emitter: summaryStylesEmitter,
+  };
+
+  return (
+    <SummaryStylesContext.Provider value={value}>
+      {children}
+    </SummaryStylesContext.Provider>
+  );
+}
+
+export function useSummaryStyles() {
+  const ctx = useContext(SummaryStylesContext);
+  if (!ctx) {
+    throw new Error('useSummaryStyles must be used within a SummaryStylesProvider');
+  }
+  return ctx;
+}

--- a/data/summaryStylesDefaults.ts
+++ b/data/summaryStylesDefaults.ts
@@ -1,0 +1,4 @@
+import { SummaryStyle } from '@/types/summary';
+
+export const DEFAULT_SUMMARY_STYLES: SummaryStyle[] = [];
+// TODO: populate with actual default styles in later phase

--- a/data/summaryStylesStore.ts
+++ b/data/summaryStylesStore.ts
@@ -1,0 +1,95 @@
+import { EventEmitter } from 'events';
+import { createRequire } from 'module';
+import type { SummaryStyle } from '../types/summary.ts';
+
+export const SUMMARY_STYLES_KEY = 'summaryStyles:v1';
+
+export interface StorageLike {
+  getItem(key: string): Promise<string | null>;
+  setItem(key: string, value: string): Promise<void>;
+  removeItem(key: string): Promise<void>;
+}
+
+const require = createRequire(import.meta.url);
+
+let storage: StorageLike;
+
+try {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const AsyncStorage = require('@react-native-async-storage/async-storage').default;
+  storage = AsyncStorage as StorageLike;
+} catch {
+  const memory: Record<string, string> = {};
+  storage = {
+    async getItem(key: string) {
+      return memory[key] ?? null;
+    },
+    async setItem(key: string, value: string) {
+      memory[key] = value;
+    },
+    async removeItem(key: string) {
+      delete memory[key];
+    },
+  };
+}
+
+export const summaryStylesEmitter = new EventEmitter();
+
+export function setStorage(custom: StorageLike) {
+  storage = custom;
+}
+
+export async function list(): Promise<SummaryStyle[]> {
+  const raw = await storage.getItem(SUMMARY_STYLES_KEY);
+  return raw ? JSON.parse(raw) : [];
+}
+
+async function persist(styles: SummaryStyle[]): Promise<void> {
+  await storage.setItem(SUMMARY_STYLES_KEY, JSON.stringify(styles));
+}
+
+export async function hydrate(defaults: SummaryStyle[] = []): Promise<SummaryStyle[]> {
+  const current = await list();
+  if (current.length === 0 && defaults.length > 0) {
+    await persist(defaults);
+    summaryStylesEmitter.emit('summaryStyles/changed');
+    return defaults;
+  }
+  return current;
+}
+
+export async function create(style: Omit<SummaryStyle, 'id' | 'updatedAt'>): Promise<SummaryStyle> {
+  const styles = await list();
+  const newStyle: SummaryStyle = {
+    ...style,
+    id: crypto.randomUUID(),
+    updatedAt: Date.now(),
+  };
+  const updated = [...styles, newStyle];
+  await persist(updated);
+  summaryStylesEmitter.emit('summaryStyles/changed');
+  return newStyle;
+}
+
+export async function update(id: string, updates: Partial<Omit<SummaryStyle, 'id' | 'updatedAt'>>): Promise<SummaryStyle | null> {
+  const styles = await list();
+  let updatedStyle: SummaryStyle | null = null;
+  const updated = styles.map(s => {
+    if (s.id === id) {
+      updatedStyle = { ...s, ...updates, updatedAt: Date.now() };
+      return updatedStyle;
+    }
+    return s;
+  });
+  if (!updatedStyle) return null;
+  await persist(updated);
+  summaryStylesEmitter.emit('summaryStyles/changed');
+  return updatedStyle;
+}
+
+export async function remove(id: string): Promise<void> {
+  const styles = await list();
+  const updated = styles.filter(s => s.id !== id);
+  await persist(updated);
+  summaryStylesEmitter.emit('summaryStyles/changed');
+}

--- a/types/summary.ts
+++ b/types/summary.ts
@@ -1,0 +1,15 @@
+export type SummaryStyle = {
+  id: string;           // uuid
+  title: string;        // shown in pickers
+  subtitle: string;     // shown in pickers
+  prompt: string;       // the AI instructions
+  updatedAt: number;    // epoch ms
+  builtIn?: boolean;    // default styles; still editable/deletable
+};
+
+export type SavedSummary = {
+  styleId: string;
+  styleTitle: string;
+  contentMd: string;    // markdown result
+  createdAt: number;    // epoch ms
+};


### PR DESCRIPTION
## Summary
- add `SummaryStylesProvider` context backed by AsyncStorage
- persist styles and emit `summaryStyles/changed` events
- unit tests for create, update, remove persistence

## Testing
- `node --test --experimental-strip-types __tests__/summaryStylesStore.test.ts`
- `npm run lint` *(fails: expo: not found)*


------
https://chatgpt.com/codex/tasks/task_e_6897efe020cc832bbacedcf59b3f24b3