### PR TITLE
Use setTimeout return type for timers

### DIFF
--- a/app/viewer/[fileId].tsx
+++ b/app/viewer/[fileId].tsx
@@ -29,8 +29,8 @@ export default function ViewerScreen() {
   const [lastAutoScrollTime, setLastAutoScrollTime] = useState(0);
   const audioPlayerRef = useRef<any>(null);
   const flatListRef = useRef<FlatList>(null);
-  const scrollTimeoutRef = useRef<NodeJS.Timeout | null>(null);
-  const autoScrollTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+  const scrollTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const autoScrollTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => {
     loadFileAndTranscript();

--- a/components/FileExplorerContent.tsx
+++ b/components/FileExplorerContent.tsx
@@ -92,8 +92,8 @@ const FileExplorerContent = forwardRef<FileExplorerContentHandles, FileExplorerC
     let optimisticMs = 0;
     let totalMs = 0;
     let success = false;
-    let watchdogTimeout: NodeJS.Timeout | null = null;
-    let finalWatchdogTimeout: NodeJS.Timeout | null = null;
+    let watchdogTimeout: ReturnType<typeof setTimeout> | null = null;
+    let finalWatchdogTimeout: ReturnType<typeof setTimeout> | null = null;
 
     try {
       setIsCreating(true);

--- a/context/FolderExplorerContext.tsx
+++ b/context/FolderExplorerContext.tsx
@@ -43,7 +43,7 @@ export function FolderExplorerProvider({ parentId, children }: FolderExplorerPro
   const [error, setError] = useState<string | null>(null);
   
   const adapter = FoldersAdapter.getInstance();
-  const refetchTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+  const refetchTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const isMountedRef = useRef(true);
   const pendingDeletedIds = useRef<Set<string>>(new Set());
 

--- a/hooks/useAudioPlayer.ts
+++ b/hooks/useAudioPlayer.ts
@@ -20,7 +20,7 @@ export function useAudioPlayer(files: AudioFile[] = []) {
   });
 
   const audioRef = useRef<HTMLAudioElement | null>(null);
-  const intervalRef = useRef<NodeJS.Timeout | null>(null);
+  const intervalRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const currentBlobUrlRef = useRef<string | null>(null);
   const pendingBlobUrlRef = useRef<string | null>(null);
   const shouldPlayAfterLoadRef = useRef<boolean>(false);

--- a/hooks/useFolderChildren.ts
+++ b/hooks/useFolderChildren.ts
@@ -27,7 +27,7 @@ export function useFolderChildren(parentId: string | null): UseFolderChildrenRes
   const [error, setError] = useState<string | null>(null);
   
   const adapter = FoldersAdapter.getInstance();
-  const refetchTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+  const refetchTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const isMountedRef = useRef(true);
 
   const generateTempId = (): string => {


### PR DESCRIPTION
## Summary
- Replace `NodeJS.Timeout` with `ReturnType<typeof setTimeout>` in timers to support native and web environments

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: ESLint couldn't find an eslint.config file)*

------
https://chatgpt.com/codex/tasks/task_e_6899124ff8bc832ba2d1876f3f620d0e