### PR TITLE
feat: add summary styles provider to layout

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,6 +1,6 @@
-import { useEffect } from 'react';
 import { Stack } from 'expo-router';
 import { StatusBar } from 'expo-status-bar';
+import { SummaryStylesProvider } from '@/context/SummaryStylesContext';
 import { useFrameworkReady } from '@/hooks/useFrameworkReady';
 
 export default function RootLayout() {
@@ -8,9 +8,11 @@ export default function RootLayout() {
 
   return (
     <>
-      <Stack screenOptions={{ headerShown: false }}>
-        <Stack.Screen name="+not-found" />
-      </Stack>
+      <SummaryStylesProvider>
+        <Stack screenOptions={{ headerShown: false }}>
+          <Stack.Screen name="+not-found" />
+        </Stack>
+      </SummaryStylesProvider>
       <StatusBar style="auto" />
     </>
   );


### PR DESCRIPTION
## Summary
- make SummaryStylesProvider available to all screens by wrapping layout stack

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689a3d84f98c832b87150c20b0335113