### PR TITLE
feat: add UUID generator utility

### DIFF
--- a/context/SummaryStylesContext.tsx
+++ b/context/SummaryStylesContext.tsx
@@ -1,5 +1,6 @@
 import React, { createContext, useContext, useState, useRef, useCallback, ReactNode } from 'react';
 import { StorageService } from '@/services/storageService';
+import { uuid } from '@/utils/uuid';
 
 interface SummaryStyle {
   id: string;
@@ -43,10 +44,6 @@ const DEFAULT_STYLES: Array<Omit<SummaryStyle, 'updatedAt'>> = [
   { id: 'key-takeaways', name: 'Key Takeaways', prompt: 'List key takeaways.', builtIn: true },
   { id: 'meeting-minutes', name: 'Meeting Minutes', prompt: 'Summarize as meeting minutes.', builtIn: true },
 ];
-
-function generateId(): string {
-  return Date.now().toString() + '_' + Math.random().toString(36).substring(2, 15);
-}
 
 interface ProviderProps {
   children: ReactNode;
@@ -108,7 +105,7 @@ export function SummaryStylesProvider({ children }: ProviderProps) {
   const create = useCallback(async (style: Omit<SummaryStyle, 'id' | 'updatedAt' | 'builtIn'>) => {
     const newStyle: SummaryStyle = {
       ...style,
-      id: generateId(),
+      id: uuid(),
       builtIn: false,
       updatedAt: Date.now(),
     };

--- a/utils/uuid.ts
+++ b/utils/uuid.ts
@@ -1,0 +1,11 @@
+export function uuid(): string {
+  if (typeof globalThis.crypto?.randomUUID === 'function') {
+    return globalThis.crypto.randomUUID();
+  }
+  // Fallback to Math.random based UUID v4 generation
+  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, c => {
+    const r = Math.random() * 16 | 0;
+    const v = c === 'x' ? r : (r & 0x3) | 0x8;
+    return v.toString(16);
+  });
+}


### PR DESCRIPTION
## Summary
- add UUID v4 generator with crypto.randomUUID fallback
- use UUID utility in SummaryStylesProvider

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689a3f40b31c832bac6151d3df488fed