### PR TITLE
refactor: centralize json handling

### DIFF
--- a/utils/json.ts
+++ b/utils/json.ts
@@ -1,0 +1,20 @@
+export function safeParse<T>(str: string | null | undefined, fallback: T): T {
+  if (str === null || str === undefined) {
+    return fallback;
+  }
+  try {
+    return JSON.parse(str) as T;
+  } catch (err) {
+    console.error('Failed to parse JSON:', err);
+    return fallback;
+  }
+}
+
+export function safeStringify(value: unknown): string | null {
+  try {
+    return JSON.stringify(value);
+  } catch (err) {
+    console.error('Failed to stringify JSON:', err);
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary
- add utility helpers for safe JSON parsing and stringifying
- apply safe JSON helpers in summary style providers
- reduce boilerplate in per-recording summary storage

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a512a9ee8832bb1466830d274c780