### PR TITLE
feat: add debounced storage and use in summary styles

### DIFF
--- a/services/__mocks__/storageService.ts
+++ b/services/__mocks__/storageService.ts
@@ -9,6 +9,10 @@ export const StorageService = {
   setItem: jest.fn(async (key: string, value: string) => {
     store[key] = value;
   }),
+  setItemDebounced: jest.fn((key: string, value: string) => {
+    store[key] = value;
+    return jest.fn();
+  }),
   removeItem: jest.fn(async (key: string) => {
     delete store[key];
   }),

--- a/services/storageService.ts
+++ b/services/storageService.ts
@@ -36,6 +36,16 @@ export class StorageService {
     }
   }
 
+  static setItemDebounced(key: string, value: string, delay: number): () => void {
+    const timeout = setTimeout(() => {
+      StorageService.setItem(key, value).catch(error => {
+        console.error('StorageService.setItemDebounced error:', error);
+      });
+    }, delay);
+
+    return () => clearTimeout(timeout);
+  }
+
   static async removeItem(key: string): Promise<void> {
     try {
       if (Platform.OS === 'web') {


### PR DESCRIPTION
## Summary
- add setItemDebounced helper that writes to storage after a delay and returns a cancel function
- use debounced storage in SummaryStylesProvider to persist style updates
- update tests and mocks for the new debounced helper

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a512b67cc832b9f884184d5752711