### PR TITLE
docs: add rollback steps to summary styles

### DIFF
--- a/docs/summary-styles.md
+++ b/docs/summary-styles.md
@@ -29,3 +29,9 @@ When no styles are found in storage, the context seeds the following built-in st
 - Action Items
 - Key Takeaways
 - Meeting Minutes
+
+## Rollback Steps
+To revert to the default summary styles if customizations cause issues:
+1. Remove the `"summaryStyles:v1"` key from storage.
+2. Call `hydrate()` to seed the built-in styles again.
+3. Reload consumers of the context so they pick up the restored styles.


### PR DESCRIPTION
## Summary
- document how to reset summary styles to defaults in `docs/summary-styles.md`

## Testing
- `npm test` (fails: Jest encountered an unexpected token in SummaryStylesContext)
- `npm run lint` (warnings only)

------
https://chatgpt.com/codex/tasks/task_e_689a5131d488832b8aa463037e83fc95