### PR TITLE
refactor: centralize logging

### DIFF
--- a/app/(tabs)/library.tsx
+++ b/app/(tabs)/library.tsx
@@ -25,6 +25,7 @@ import DateFilterChip from '@/components/DateFilterChip';
 import { useDateFilter } from '@/hooks/useDateFilter';
 import { TranscriptService } from '@/services/transcriptService';
 import { AudioStorageService } from '@/services/audioStorage';
+import logger from '@/utils/logger';
 
 const styles = StyleSheet.create({
   actionBar: {
@@ -252,11 +253,11 @@ export default function LibraryScreen() {
   };
 
   const handleTranscribeFile = async (file: any) => {
-    console.log('🎯 handleTranscribeFile called for:', file.name, 'hasTranscript:', file.hasTranscript);
+    logger.log('🎯 handleTranscribeFile called for:', file.name, 'hasTranscript:', file.hasTranscript);
     
     // If file already has transcript, navigate to viewer instead
     if (file.hasTranscript) {
-      console.log('📖 File already has transcript, navigating to viewer');
+      logger.log('📖 File already has transcript, navigating to viewer');
       router.push(`/viewer/${file.id}`);
       return;
     }
@@ -277,10 +278,10 @@ export default function LibraryScreen() {
     resetTranscription();
 
     try {
-      console.log('🚀 Starting transcription for:', file.name);
+      logger.log('🚀 Starting transcription for:', file.name);
       const result = await transcribeFileFromHook(file, apiKey);
       
-      console.log('💾 Creating transcript from result...');
+      logger.log('💾 Creating transcript from result...');
       const storedTranscript = await TranscriptService.createTranscriptFromWhisper(
         file.id,
         result.segments,
@@ -289,18 +290,18 @@ export default function LibraryScreen() {
         result.duration
       );
       
-      console.log('🔍 Verifying stored transcript...');
+      logger.log('🔍 Verifying stored transcript...');
       const verifyTranscript = await TranscriptService.getTranscriptByFileId(file.id);
       
       if (!verifyTranscript) {
         throw new Error('Failed to retrieve stored transcript');
       }
       
-      console.log('✅ Updating file transcript status...');
+      logger.log('✅ Updating file transcript status...');
       // Update transcript status without full refresh
       await updateFileTranscriptStatus(file.id, true);
       
-      console.log('🎉 Transcription completed successfully, navigating to viewer...');
+      logger.log('🎉 Transcription completed successfully, navigating to viewer...');
       setTimeout(() => {
         setShowTranscriptionModal(false);
         setTranscribingFile(null);
@@ -309,7 +310,7 @@ export default function LibraryScreen() {
       }, 1000);
       
     } catch (error) {
-      console.error('❌ Transcription failed:', error);
+      logger.error('❌ Transcription failed:', error);
       // Don't navigate away on error - keep the modal open to show error state
     }
   };

--- a/app/api/transcribe+api.ts
+++ b/app/api/transcribe+api.ts
@@ -1,3 +1,5 @@
+import logger from '@/utils/logger';
+
 export async function POST(request: Request) {
   const corsHeaders = {
     'Access-Control-Allow-Origin': '*',
@@ -16,7 +18,7 @@ export async function POST(request: Request) {
     const apiKey = process.env.OPENAI_API_KEY;
     
     if (!apiKey) {
-      console.error('OpenAI API key not found');
+      logger.error('OpenAI API key not found');
       return new Response(
         JSON.stringify({ 
           error: 'API key not configured',
@@ -42,7 +44,7 @@ export async function POST(request: Request) {
       );
     }
 
-    console.log('Processing audio file:', audioFile.name, audioFile.size, 'bytes');
+    logger.log('Processing audio file:', audioFile.name, audioFile.size, 'bytes');
 
     // Prepare FormData for OpenAI
     const whisperFormData = new FormData();
@@ -51,7 +53,7 @@ export async function POST(request: Request) {
     whisperFormData.append('response_format', 'verbose_json');
     whisperFormData.append('temperature', '0');
 
-    console.log('📡 Calling OpenAI Whisper API...');
+    logger.log('📡 Calling OpenAI Whisper API...');
 
     const openaiResponse = await fetch('https://api.openai.com/v1/audio/transcriptions', {
       method: 'POST',
@@ -63,7 +65,7 @@ export async function POST(request: Request) {
 
     if (!openaiResponse.ok) {
       const errorData = await openaiResponse.text();
-      console.error('OpenAI API error:', openaiResponse.status, errorData);
+      logger.error('OpenAI API error:', openaiResponse.status, errorData);
       
       let userFriendlyMessage = 'Transcription service temporarily unavailable';
       
@@ -87,11 +89,11 @@ export async function POST(request: Request) {
 
     const transcriptionData = await openaiResponse.json();
     
-    console.log('📥 Raw OpenAI response:', JSON.stringify(transcriptionData, null, 2));
+    logger.log('📥 Raw OpenAI response:', JSON.stringify(transcriptionData, null, 2));
     
     // Validate response
     if (!transcriptionData.text || typeof transcriptionData.text !== 'string') {
-      console.error('❌ No valid text in response');
+      logger.error('❌ No valid text in response');
       return new Response(
         JSON.stringify({ 
           error: 'Invalid transcription',
@@ -107,7 +109,7 @@ export async function POST(request: Request) {
     // Check for prompt injection
     if (transcriptionData.text.includes('Include all spoken content') ||
         transcriptionData.text.includes('Transcribe the complete audio')) {
-      console.error('❌ Prompt injection detected');
+      logger.error('❌ Prompt injection detected');
       return new Response(
         JSON.stringify({ 
           error: 'Invalid transcription',
@@ -122,7 +124,7 @@ export async function POST(request: Request) {
 
     // Validate minimum content
     if (transcriptionData.text.length < 5) {
-      console.error('❌ Transcript too short');
+      logger.error('❌ Transcript too short');
       return new Response(
         JSON.stringify({ 
           error: 'Empty transcription',
@@ -135,7 +137,7 @@ export async function POST(request: Request) {
       );
     }
 
-    console.log('✅ Valid transcription received:', {
+    logger.log('✅ Valid transcription received:', {
       textLength: transcriptionData.text.length,
       segmentCount: transcriptionData.segments?.length || 0,
       language: transcriptionData.language,
@@ -156,7 +158,7 @@ export async function POST(request: Request) {
     );
 
   } catch (error) {
-    console.error('❌ Transcription error:', error);
+    logger.error('❌ Transcription error:', error);
     
     return new Response(
       JSON.stringify({ 

--- a/app/file-explorer.tsx
+++ b/app/file-explorer.tsx
@@ -11,6 +11,7 @@ import { FoldersAdapter } from '@/services/foldersAdapter';
 import { AudioFile } from '@/types/audio';
 import { Folder } from '@/types/folder';
 import { RecordingsStore } from '@/data/recordingsStore';
+import logger from '@/utils/logger';
 
 export default function FileExplorerScreen() {
   const [currentFolderId, setCurrentFolderId] = useState<string | null>(null);
@@ -28,13 +29,13 @@ export default function FileExplorerScreen() {
     loadRecordingsAndPath();
     
     // Debug: Log what we're loading
-    console.log('🔍 FileExplorer: Loading content for folderId:', currentFolderId);
+    logger.log('🔍 FileExplorer: Loading content for folderId:', currentFolderId);
   }, [currentFolderId]);
 
   // Refresh content when screen comes into focus
   useFocusEffect(
     React.useCallback(() => {
-      console.log('🔄 FileExplorer: Screen focused, refreshing content');
+      logger.log('🔄 FileExplorer: Screen focused, refreshing content');
       loadRecordings(); // Only load recordings here, path is handled by context
     }, [currentFolderId]) // Depend on currentFolderId
   );
@@ -43,7 +44,7 @@ export default function FileExplorerScreen() {
     try {
       setPathLoading(true);
       
-      console.log('🔍 FileExplorer: Starting to load folder content for:', currentFolderId);
+      logger.log('🔍 FileExplorer: Starting to load folder content for:', currentFolderId);
       
       // Load recordings and path for current location
       const [recordingsData, pathData] = await Promise.all([
@@ -51,7 +52,7 @@ export default function FileExplorerScreen() {
         adapter.getPath(currentFolderId)
       ]);
       
-      console.log('🔍 FileExplorer: Loaded data:', {
+      logger.log('🔍 FileExplorer: Loaded data:', {
         recordingsCount: recordingsData.length,
         pathLength: pathData.length
       });
@@ -59,7 +60,7 @@ export default function FileExplorerScreen() {
       setRecordings(recordingsData);
       setFolderPath(pathData);
     } catch (error) {
-      console.error('Failed to load folder content:', error);
+      logger.error('Failed to load folder content:', error);
       Alert.alert('Error', 'Failed to load folder content');
     } finally {
       setRecordingsLoading(false);
@@ -72,7 +73,7 @@ export default function FileExplorerScreen() {
       const recordingsData = await adapter.getRecordingsInFolder(currentFolderId);
       setRecordings(recordingsData);
     } catch (error) {
-      console.error('Failed to load recordings:', error);
+      logger.error('Failed to load recordings:', error);
     }
   };
 

--- a/app/tag-explorer.tsx
+++ b/app/tag-explorer.tsx
@@ -11,6 +11,7 @@ import ConfirmModal from '@/components/ConfirmModal';
 import SnackBar from '@/components/SnackBar';
 import { RecordingsStore } from '@/data/recordingsStore';
 import { Tag } from '@/types/tag';
+import logger from '@/utils/logger';
 
 interface TagWithCount extends Tag {
   recordingCount: number;
@@ -125,7 +126,7 @@ export default function TagExplorerScreen() {
       const tagsWithCounts = await RecordingsStore.getTagsWithCounts();
       setTags(tagsWithCounts);
     } catch (error) {
-      console.error('Failed to load tags:', error);
+      logger.error('Failed to load tags:', error);
       Alert.alert('Error', 'Failed to load tags');
     } finally {
       setLoading(false);

--- a/app/viewer/[fileId].tsx
+++ b/app/viewer/[fileId].tsx
@@ -12,6 +12,7 @@ import { AudioStorageService } from '@/services/audioStorage';
 import { TranscriptService } from '@/services/transcriptService';
 import { AudioFile } from '@/types/audio';
 import { Transcript, TranscriptSegment } from '@/types/transcript';
+import logger from '@/utils/logger';
 
 export default function ViewerScreen() {
   const { fileId } = useLocalSearchParams<{ fileId: string }>();
@@ -121,7 +122,7 @@ export default function ViewerScreen() {
           setLastAutoScrollTime(Date.now());
         } catch (error) {
           // Fallback to scrollToOffset if scrollToIndex fails
-          console.warn('ScrollToIndex failed, using fallback scroll');
+          logger.warn('ScrollToIndex failed, using fallback scroll');
           const estimatedOffset = segmentIndex * 100; // Estimate based on average segment height
           flatListRef.current.scrollToOffset({
             offset: estimatedOffset,
@@ -153,7 +154,7 @@ export default function ViewerScreen() {
       // Scroll to the segment
       scrollToActiveSegment(segment.id);
       
-      console.log(`Seeking to timestamp: ${timestamp}s`);
+      logger.log(`Seeking to timestamp: ${timestamp}s`);
     }
   };
 
@@ -221,7 +222,7 @@ export default function ViewerScreen() {
   };
 
   const handleSearchMatchSelect = (segment: TranscriptSegment, matchIndex: number) => {
-    console.log('🔍 Search match selected:', {
+    logger.log('🔍 Search match selected:', {
       segmentId: segment.id,
       startTime: segment.startTime,
       text: segment.text.substring(0, 50) + '...'
@@ -239,7 +240,7 @@ export default function ViewerScreen() {
     setIsUserScrolling(false);
     scrollToActiveSegment(segment.id);
     
-    console.log(`🔍 Navigated to search match at ${segment.startTime}s`);
+    logger.log(`🔍 Navigated to search match at ${segment.startTime}s`);
   };
 
   const formatFileSize = (bytes: number): string => {
@@ -402,12 +403,11 @@ export default function ViewerScreen() {
         <AudioPlayerModule
           ref={audioPlayerRef}
           audioFile={file}
-          onPlayPause={() => console.log('Play/Pause')}
-          onSkipBack={() => console.log('Skip back')}
-          onSkipForward={() => console.log('Skip forward')}
-          onSpeedChange={(speed) => console.log('Speed changed:', speed)}
-          onSeek={(time) => {
-            console.log('Seek to:', time);
+          onPlayPause={() => {}}
+          onSkipBack={() => {}}
+          onSkipForward={() => {}}
+          onSpeedChange={() => {}}
+          onSeek={(_time) => {
             // Reset user scrolling when seeking manually
             setIsUserScrolling(false);
           }}

--- a/hooks/useAudioFiles.ts
+++ b/hooks/useAudioFiles.ts
@@ -3,6 +3,7 @@ import { AudioFile } from '@/types/audio';
 import { AudioStorageService } from '@/services/audioStorage';
 import { TranscriptService } from '@/services/transcriptService';
 import { RecordingsStore } from '@/data/recordingsStore';
+import logger from '@/utils/logger';
 
 export function useAudioFiles() {
   const [files, setFiles] = useState<AudioFile[]>([]);
@@ -36,7 +37,7 @@ export function useAudioFiles() {
       setFiles(filesWithTranscriptStatus);
     } catch (err) {
       setError('Failed to load audio files');
-      console.error('Error loading files:', err);
+      logger.error('Error loading files:', err);
     } finally {
       setLoading(false);
     }
@@ -114,7 +115,7 @@ export function useAudioFiles() {
       // Update the file in storage
       await AudioStorageService.updateFileTranscriptStatus(fileId, hasTranscript);
       
-      console.log(`✅ Updated transcript status for ${fileId}: ${hasTranscript}`);
+      logger.log(`✅ Updated transcript status for ${fileId}: ${hasTranscript}`);
     } catch (err) {
       // Rollback on error - restore original file
       if (originalFile) {
@@ -125,7 +126,7 @@ export function useAudioFiles() {
       
       const errorMessage = err instanceof Error ? err.message : 'Failed to update transcript status';
       setError(errorMessage);
-      console.error('Error updating transcript status:', err);
+      logger.error('Error updating transcript status:', err);
     }
   }, []);
 

--- a/hooks/useAudioPlayer.ts
+++ b/hooks/useAudioPlayer.ts
@@ -1,6 +1,7 @@
 import { useState, useRef, useCallback, useEffect } from 'react';
 import { AudioFile } from '@/types/audio';
 import { useGlobalAudioManager } from '@/hooks/useGlobalAudioManager';
+import logger from '@/utils/logger';
 
 interface AudioPlayerState {
   currentFileId: string | null;
@@ -31,7 +32,7 @@ export function useAudioPlayer(files: AudioFile[] = []) {
       const currentFile = files.find(f => f.id === playerState.currentFileId);
       if (currentFile && currentFile.uri !== audioRef.current.src) {
         // Blob URL has changed, update the audio source
-        console.log('🔄 Updating audio source for file:', currentFile.name);
+        logger.log('🔄 Updating audio source for file:', currentFile.name);
         loadAudioFile(currentFile);
       }
     }
@@ -66,7 +67,7 @@ export function useAudioPlayer(files: AudioFile[] = []) {
             startTimeTracking();
             setPlayerState(prev => ({ ...prev, isPlaying: true }));
           }).catch(error => {
-            console.error('Audio playback error:', error);
+            logger.error('Audio playback error:', error);
           });
           shouldPlayAfterLoadRef.current = false;
         }
@@ -149,7 +150,7 @@ export function useAudioPlayer(files: AudioFile[] = []) {
     // Find the file from the files array if not provided
     const targetFile = audioFile || files.find(f => f.id === fileId);
     if (!targetFile) {
-      console.error('File not found for playback:', fileId);
+      logger.error('File not found for playback:', fileId);
       return;
     }
 
@@ -186,7 +187,7 @@ export function useAudioPlayer(files: AudioFile[] = []) {
         }
       }
     } catch (error) {
-      console.error('Audio playback error:', error);
+      logger.error('Audio playback error:', error);
       shouldPlayAfterLoadRef.current = false; // Clear flag on error
     }
   }, [stopAllAudio, files, playerState.currentFileId, playerState.isPlaying, stopTimeTracking, loadAudioFile, startTimeTracking, setCurrentAudio]);
@@ -231,7 +232,7 @@ export function useAudioPlayer(files: AudioFile[] = []) {
           currentTime: 0,
           currentFileId: null,
         }));
-        console.log('🛑 Stopped playback for deleted file:', fileId);
+        logger.log('🛑 Stopped playback for deleted file:', fileId);
       }
     }, [playerState.currentFileId, playerState.isPlaying, stopTimeTracking]),
   };

--- a/hooks/useFolders.ts
+++ b/hooks/useFolders.ts
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback } from 'react';
 import { Folder, FolderFilter } from '@/types/folder';
 import { FoldersAdapter, FolderWithCounts, FolderEvent } from '@/services/foldersAdapter';
+import logger from '@/utils/logger';
 
 export function useFolders() {
   const [folders, setFolders] = useState<FolderWithCounts[]>([]);
@@ -22,7 +23,7 @@ export function useFolders() {
       setFolders(allFolders);
     } catch (err) {
       setError('Failed to load folders');
-      console.error('Error loading folders:', err);
+      logger.error('Error loading folders:', err);
     } finally {
       setLoading(false);
     }
@@ -83,7 +84,7 @@ export function useFolders() {
   // Subscribe to folder change events
   useEffect(() => {
     const unsubscribe = adapter.watch((event?: FolderEvent) => {
-      console.log('🔄 useFolders: Received folder change event:', event);
+      logger.log('🔄 useFolders: Received folder change event:', event);
       loadFolders();
     });
     

--- a/hooks/useGlobalAudioManager.ts
+++ b/hooks/useGlobalAudioManager.ts
@@ -1,4 +1,5 @@
 import { useRef, useCallback } from 'react';
+import logger from '@/utils/logger';
 
 // Global audio manager to ensure only one audio plays at a time
 class GlobalAudioManager {
@@ -14,11 +15,11 @@ class GlobalAudioManager {
   }
 
   stopAll(): void {
-    console.log('🛑 GlobalAudioManager: Stopping all audio');
+    logger.log('🛑 GlobalAudioManager: Stopping all audio');
     
     // Stop our tracked audio
     if (this.currentAudio) {
-      console.log('  - Stopping tracked audio for file:', this.currentFileId);
+      logger.log('  - Stopping tracked audio for file:', this.currentFileId);
       this.currentAudio.pause();
       this.currentAudio.currentTime = 0;
     }
@@ -27,7 +28,7 @@ class GlobalAudioManager {
     const allAudioElements = document.querySelectorAll('audio');
     allAudioElements.forEach((audio, index) => {
       if (!audio.paused) {
-        console.log(`  - Force stopping audio element ${index + 1}`);
+        logger.log(`  - Force stopping audio element ${index + 1}`);
         audio.pause();
         audio.currentTime = 0;
       }
@@ -38,7 +39,7 @@ class GlobalAudioManager {
   }
 
   setCurrentAudio(audio: HTMLAudioElement, fileId: string): void {
-    console.log('🎵 GlobalAudioManager: Setting current audio for file:', fileId);
+    logger.log('🎵 GlobalAudioManager: Setting current audio for file:', fileId);
     
     // Stop any existing audio first
     this.stopAll();

--- a/hooks/useTags.ts
+++ b/hooks/useTags.ts
@@ -2,6 +2,7 @@ import { useState, useEffect, useCallback } from 'react';
 import { Tag, TagFilter } from '@/types/tag';
 import { TagService } from '@/services/tagService';
 import { RecordingsStore } from '@/data/recordingsStore';
+import logger from '@/utils/logger';
 
 export function useTags() {
   const [tags, setTags] = useState<Tag[]>([]);
@@ -21,7 +22,7 @@ export function useTags() {
       setTags(allTags);
     } catch (err) {
       setError('Failed to load tags');
-      console.error('Error loading tags:', err);
+      logger.error('Error loading tags:', err);
     } finally {
       setLoading(false);
     }

--- a/hooks/useTranscription.ts
+++ b/hooks/useTranscription.ts
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { WhisperService } from '@/services/whisperService';
 import { TranscriptService } from '@/services/transcriptService';
+import logger from '@/utils/logger';
 
 export interface AudioFile {
   id: string;
@@ -16,7 +17,7 @@ export function useTranscription() {
   const [error, setError] = useState<string | null>(null);
 
   const transcribeFile = async (file: AudioFile, apiKey: string) => {
-    console.log('🎯 useTranscription.transcribeFile called with:', file.id, file.name);
+    logger.log('🎯 useTranscription.transcribeFile called with:', file.id, file.name);
     
     setIsTranscribing(true);
     setProgress(0);
@@ -26,12 +27,12 @@ export function useTranscription() {
       // Simulate progress updates
       setProgress(10);
       
-      console.log('📡 Calling WhisperService.safeTranscribe...');
+      logger.log('📡 Calling WhisperService.safeTranscribe...');
       const result = await WhisperService.safeTranscribe(file, apiKey);
       
       setProgress(80);
       
-      console.log('💾 Storing transcript in TranscriptService...');
+      logger.log('💾 Storing transcript in TranscriptService...');
       const storedTranscript = await TranscriptService.createTranscriptFromWhisper(
         file.id,
         result.segments || [],
@@ -42,7 +43,7 @@ export function useTranscription() {
       
       setProgress(100);
       
-      console.log('✅ Transcription completed successfully:', {
+      logger.log('✅ Transcription completed successfully:', {
         storedId: storedTranscript.id,
         textLength: storedTranscript.fullText.length,
         segmentCount: storedTranscript.segments.length
@@ -51,7 +52,7 @@ export function useTranscription() {
       return result;
       
     } catch (error) {
-      console.error('❌ Transcription failed:', error);
+      logger.error('❌ Transcription failed:', error);
       const errorMessage = error instanceof Error ? error.message : 'Transcription failed';
       setError(errorMessage);
       throw error;

--- a/services/audioStorage.ts
+++ b/services/audioStorage.ts
@@ -2,6 +2,7 @@ import * as FileSystem from 'expo-file-system';
 import { Platform } from 'react-native';
 import { AudioFile, AudioFileMetadata } from '@/types/audio';
 import { StorageService } from './storageService';
+import logger from '@/utils/logger';
 
 const STORAGE_KEY = 'audio_files';
 const AUDIO_DIR = `${FileSystem.documentDirectory}RecorderGearApp/AudioFiles/`;
@@ -18,16 +19,16 @@ export class AudioStorageService {
         await FileSystem.makeDirectoryAsync(AUDIO_DIR, { intermediates: true });
       }
     } catch (error) {
-      console.error('Failed to initialize audio storage:', error);
+      logger.error('Failed to initialize audio storage:', error);
     }
   }
 
   static async clearAllFiles(): Promise<void> {
     try {
       await StorageService.removeItem(STORAGE_KEY);
-      console.log('⚠️ All audio files cleared from storage');
+      logger.log('⚠️ All audio files cleared from storage');
     } catch (error) {
-      console.error('Failed to clear audio files:', error);
+      logger.error('Failed to clear audio files:', error);
       throw error;
     }
   }
@@ -73,7 +74,7 @@ export class AudioStorageService {
         
         return audioFile;
       } catch (error) {
-        console.error('Failed to create blob URL:', error instanceof Error ? error.message : 'Unknown error');
+        logger.error('Failed to create blob URL:', error instanceof Error ? error.message : 'Unknown error');
         
         // Check for storage quota exceeded error
         if (error instanceof DOMException && error.name === 'QuotaExceededError') {
@@ -112,7 +113,7 @@ export class AudioStorageService {
         
         return audioFile;
       } catch (error) {
-        console.error('Failed to save audio file:', error);
+        logger.error('Failed to save audio file:', error);
         throw new Error('Failed to import file. Please try again.');
       }
     }
@@ -175,7 +176,7 @@ export class AudioStorageService {
         return nameMatch && sizeMatch;
       });
     } catch (error) {
-      console.error('Error checking for duplicates:', error);
+      logger.error('Error checking for duplicates:', error);
       return false;
     }
   }
@@ -192,7 +193,7 @@ export class AudioStorageService {
       
       await StorageService.setItem(STORAGE_KEY, JSON.stringify(filesToStore));
     } catch (error) {
-      console.error('Failed to save file metadata:', error);
+      logger.error('Failed to save file metadata:', error);
       throw error;
     }
   }
@@ -203,7 +204,7 @@ export class AudioStorageService {
       const updatedFiles = [...existingFiles, audioFile];
       await this._saveAllFileMetadata(updatedFiles);
     } catch (error) {
-      console.error('Failed to save file metadata:', error);
+      logger.error('Failed to save file metadata:', error);
       throw error;
     }
   }
@@ -231,7 +232,7 @@ export class AudioStorageService {
       // Sort by import date (newest first)
       return files.sort((a, b) => new Date(b.importDate).getTime() - new Date(a.importDate).getTime());
     } catch (error) {
-      console.error('Failed to get audio files:', error);
+      logger.error('Failed to get audio files:', error);
       return [];
     }
   }
@@ -255,7 +256,7 @@ export class AudioStorageService {
         await this._saveAllFileMetadata(updatedFiles);
       }
     } catch (error) {
-      console.error('Failed to delete file:', error);
+      logger.error('Failed to delete file:', error);
       throw new Error('Failed to delete file. Please try again.');
     }
   }
@@ -265,29 +266,29 @@ export class AudioStorageService {
       const files = await this.getAllFiles();
       return files.find(f => f.id === fileId) || null;
     } catch (error) {
-      console.error('Failed to get file by ID:', error);
+      logger.error('Failed to get file by ID:', error);
       return null;
     }
   }
 
   static async updateFileTranscriptStatus(fileId: string, hasTranscript: boolean): Promise<void> {
     try {
-      console.log(`🔄 Updating transcript status for ${fileId}: ${hasTranscript}`);
+      logger.log(`🔄 Updating transcript status for ${fileId}: ${hasTranscript}`);
       const files = await this.getAllFiles();
-      console.log(`📁 Current files count: ${files.length}`);
+      logger.log(`📁 Current files count: ${files.length}`);
       
       const updatedFiles = files.map(file => 
         file.id === fileId ? { ...file, hasTranscript } : file
       );
       
-      console.log(`📁 Updated files count: ${updatedFiles.length}`);
+      logger.log(`📁 Updated files count: ${updatedFiles.length}`);
       const targetFile = updatedFiles.find(f => f.id === fileId);
-      console.log(`🎯 Target file found:`, !!targetFile, targetFile ? `hasTranscript: ${targetFile.hasTranscript}` : 'not found');
+      logger.log(`🎯 Target file found:`, !!targetFile, targetFile ? `hasTranscript: ${targetFile.hasTranscript}` : 'not found');
       
       await this._saveAllFileMetadata(updatedFiles);
-      console.log(`✅ File transcript status updated successfully`);
+      logger.log(`✅ File transcript status updated successfully`);
     } catch (error) {
-      console.error('Failed to update transcript status:', error);
+      logger.error('Failed to update transcript status:', error);
       throw error;
     }
   }
@@ -311,7 +312,7 @@ export class AudioStorageService {
       
       return updatedFile;
     } catch (error) {
-      console.error('Failed to update audio file:', error);
+      logger.error('Failed to update audio file:', error);
       throw error;
     }
   }
@@ -369,11 +370,11 @@ export class AudioStorageService {
       
       await this._saveAllFileMetadata(updatedFiles);
       
-      console.log(`✅ File renamed from "${fileToRename.name}" to "${newFileName}"`);
+      logger.log(`✅ File renamed from "${fileToRename.name}" to "${newFileName}"`);
       return updatedFile;
       
     } catch (error) {
-      console.error('Failed to rename file:', error);
+      logger.error('Failed to rename file:', error);
       throw error;
     }
   }

--- a/services/foldersAdapter.ts
+++ b/services/foldersAdapter.ts
@@ -1,6 +1,7 @@
 import { Folder } from '@/types/folder';
 import { RecordingsStore } from '@/data/recordingsStore';
 import { FolderService } from '@/services/folderService';
+import logger from '@/utils/logger';
 
 export interface FolderEvent {
   type: 'folders_changed';
@@ -54,7 +55,7 @@ export class FoldersAdapter {
   }
 
   private invalidateCache(): void {
-    console.log('🗑️ FoldersAdapter: Invalidating all caches');
+    logger.log('🗑️ FoldersAdapter: Invalidating all caches');
     this.allFoldersCache = null;
     this.validMoveTargetsCache = null;
   }
@@ -80,7 +81,7 @@ export class FoldersAdapter {
       },
     };
     
-    console.log('📡 FoldersAdapter emitting event:', event);
+    logger.log('📡 FoldersAdapter emitting event:', event);
     
     // Notify RecordingsStore to trigger cross-tab sync and other listeners
     RecordingsStore.notifyStoreChanged(false, event);
@@ -111,10 +112,10 @@ export class FoldersAdapter {
    */
   async listChildren(parentId: string | null): Promise<FolderWithCounts[]> {
     try {
-      console.log('🔍 FoldersAdapter.listChildren called with parentId:', parentId);
+      logger.log('🔍 FoldersAdapter.listChildren called with parentId:', parentId);
       return await RecordingsStore.getFoldersWithCounts(parentId);
     } catch (error) {
-      console.error('Failed to list folder children:', error);
+      logger.error('Failed to list folder children:', error);
       return [];
     }
   }
@@ -132,7 +133,7 @@ export class FoldersAdapter {
       this.emitEvent('create', newFolder.id, parentId);
       return newFolder;
     } catch (error) {
-      console.error('Failed to create folder:', error);
+      logger.error('Failed to create folder:', error);
       throw error;
     }
   }
@@ -146,7 +147,7 @@ export class FoldersAdapter {
       this.emitEvent('rename', id, renamedFolder.parentId);
       return renamedFolder;
     } catch (error) {
-      console.error('Failed to rename folder:', error);
+      logger.error('Failed to rename folder:', error);
       throw error;
     }
   }
@@ -160,7 +161,7 @@ export class FoldersAdapter {
       this.emitEvent('move', id, newParentId);
       return movedFolder;
     } catch (error) {
-      console.error('Failed to move folder:', error);
+      logger.error('Failed to move folder:', error);
       throw error;
     }
   }
@@ -177,7 +178,7 @@ export class FoldersAdapter {
       await RecordingsStore.deleteFolder(id);
       this.emitEvent('delete', id, parentId);
     } catch (error) {
-      console.error('Failed to remove folder:', error);
+      logger.error('Failed to remove folder:', error);
       throw error;
     }
   }
@@ -189,7 +190,7 @@ export class FoldersAdapter {
     try {
       return await RecordingsStore.getFolderPath(id);
     } catch (error) {
-      console.error('Failed to get folder path:', error);
+      logger.error('Failed to get folder path:', error);
       return [];
     }
   }
@@ -201,7 +202,7 @@ export class FoldersAdapter {
     try {
       return await FolderService.getFolderDepth(id);
     } catch (error) {
-      console.error('Failed to get folder depth:', error);
+      logger.error('Failed to get folder depth:', error);
       return 0;
     }
   }
@@ -216,7 +217,7 @@ export class FoldersAdapter {
         folder.name.toLowerCase() === name.toLowerCase()
       );
     } catch (error) {
-      console.error('Failed to check folder existence:', error);
+      logger.error('Failed to check folder existence:', error);
       return false;
     }
   }
@@ -229,11 +230,11 @@ export class FoldersAdapter {
       // Check cache first
       const now = Date.now();
       if (this.allFoldersCache && (now - this.allFoldersCache.timestamp) < FoldersAdapter.CACHE_DURATION_MS) {
-        console.log('🚀 FoldersAdapter: Using cached all folders');
+        logger.log('🚀 FoldersAdapter: Using cached all folders');
         return this.allFoldersCache.data;
       }
       
-      console.log('🔄 FoldersAdapter: Cache miss, fetching fresh all folders');
+      logger.log('🔄 FoldersAdapter: Cache miss, fetching fresh all folders');
       const folders = await RecordingsStore.getFolders();
       
       // Cache the result
@@ -244,7 +245,7 @@ export class FoldersAdapter {
       
       return folders;
     } catch (error) {
-      console.error('Failed to get all folders:', error);
+      logger.error('Failed to get all folders:', error);
       return [];
     }
   }
@@ -256,7 +257,7 @@ export class FoldersAdapter {
     try {
       return await RecordingsStore.getRecordingsInFolder(folderId);
     } catch (error) {
-      console.error('Failed to get recordings in folder:', error);
+      logger.error('Failed to get recordings in folder:', error);
       return [];
     }
   }
@@ -269,11 +270,11 @@ export class FoldersAdapter {
       // Check cache first
       const now = Date.now();
       if (this.validMoveTargetsCache && (now - this.validMoveTargetsCache.timestamp) < FoldersAdapter.CACHE_DURATION_MS) {
-        console.log('🚀 FoldersAdapter: Using cached valid move targets');
+        logger.log('🚀 FoldersAdapter: Using cached valid move targets');
         return this.validMoveTargetsCache.data;
       }
       
-      console.log('🔄 FoldersAdapter: Cache miss, fetching fresh valid move targets');
+      logger.log('🔄 FoldersAdapter: Cache miss, fetching fresh valid move targets');
       const allFolders = await this.getAllFolders();
       const validTargets: Folder[] = [];
       
@@ -294,7 +295,7 @@ export class FoldersAdapter {
       
       return sortedTargets;
     } catch (error) {
-      console.error('Failed to get valid move targets:', error);
+      logger.error('Failed to get valid move targets:', error);
       return [];
     }
   }

--- a/services/storageService.ts
+++ b/services/storageService.ts
@@ -1,6 +1,7 @@
 import { Platform } from 'react-native';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { get, set, del } from 'idb-keyval';
+import logger from '@/utils/logger';
 
 export class StorageService {
   /**
@@ -18,7 +19,7 @@ export class StorageService {
         return await AsyncStorage.getItem(key);
       }
     } catch (error) {
-      console.error('StorageService.getItem error:', error);
+      logger.error('StorageService.getItem error:', error);
       return null;
     }
   }
@@ -31,7 +32,7 @@ export class StorageService {
         await AsyncStorage.setItem(key, value);
       }
     } catch (error) {
-      console.error('StorageService.setItem error:', error);
+      logger.error('StorageService.setItem error:', error);
       throw error;
     }
   }
@@ -44,7 +45,7 @@ export class StorageService {
         await AsyncStorage.removeItem(key);
       }
     } catch (error) {
-      console.error('StorageService.removeItem error:', error);
+      logger.error('StorageService.removeItem error:', error);
       throw error;
     }
   }
@@ -60,7 +61,7 @@ export class StorageService {
         return await AsyncStorage.getAllKeys();
       }
     } catch (error) {
-      console.error('StorageService.getAllKeys error:', error);
+      logger.error('StorageService.getAllKeys error:', error);
       return [];
     }
   }

--- a/services/tagService.ts
+++ b/services/tagService.ts
@@ -1,5 +1,6 @@
 import { Tag } from '@/types/tag';
 import { StorageService } from './storageService';
+import logger from '@/utils/logger';
 
 export class TagService {
   private static readonly STORAGE_KEY = 'tags';
@@ -34,7 +35,7 @@ export class TagService {
       const tags: Tag[] = JSON.parse(tagsJson);
       return tags.sort((a, b) => a.name.localeCompare(b.name));
     } catch (error) {
-      console.error('Failed to get tags:', error);
+      logger.error('Failed to get tags:', error);
       return [];
     }
   }
@@ -67,10 +68,10 @@ export class TagService {
       const updatedTags = [...existingTags, newTag];
       await StorageService.setItem(this.STORAGE_KEY, JSON.stringify(updatedTags));
       
-      console.log('✅ Tag created:', newTag.name);
+      logger.log('✅ Tag created:', newTag.name);
       return newTag;
     } catch (error) {
-      console.error('Failed to create tag:', error);
+      logger.error('Failed to create tag:', error);
       throw error;
     }
   }
@@ -81,9 +82,9 @@ export class TagService {
       const updatedTags = tags.filter(t => t.id !== tagId);
       await StorageService.setItem(this.STORAGE_KEY, JSON.stringify(updatedTags));
       
-      console.log('✅ Tag deleted:', tagId);
+      logger.log('✅ Tag deleted:', tagId);
     } catch (error) {
-      console.error('Failed to delete tag:', error);
+      logger.error('Failed to delete tag:', error);
       throw error;
     }
   }
@@ -124,10 +125,10 @@ export class TagService {
       
       await StorageService.setItem(this.STORAGE_KEY, JSON.stringify(updatedTags));
       
-      console.log('✅ Tag renamed:', updatedTag.name);
+      logger.log('✅ Tag renamed:', updatedTag.name);
       return updatedTag;
     } catch (error) {
-      console.error('Failed to rename tag:', error);
+      logger.error('Failed to rename tag:', error);
       throw error;
     }
   }

--- a/services/transcriptService.ts
+++ b/services/transcriptService.ts
@@ -1,5 +1,6 @@
 import { Transcript, TranscriptSegment } from '@/types/transcript';
 import { StorageService } from './storageService';
+import logger from '@/utils/logger';
 
 export class TranscriptService {
   private static readonly STORAGE_KEY = 'transcripts';
@@ -8,25 +9,25 @@ export class TranscriptService {
   static async debugStorage(fileId: string): Promise<void> {
     try {
       const key = `transcript-${fileId}`;
-      console.log('🔍 Debug storage check for fileId:', fileId);
-      console.log('🔑 Debug key:', key);
+      logger.log('🔍 Debug storage check for fileId:', fileId);
+      logger.log('🔑 Debug key:', key);
       
       const value = await StorageService.getItem(key);
-      console.log('🔍 Debug retrieved value exists:', value !== null);
-      console.log('🔍 Debug retrieved value preview:', 
+      logger.log('🔍 Debug retrieved value exists:', value !== null);
+      logger.log('🔍 Debug retrieved value preview:', 
         value ? value.substring(0, 200) + '...' : 'null'
       );
       
       // Show all keys for comparison
       const allKeys = await StorageService.getAllKeys();
-      console.log('🔍 All storage keys:', allKeys);
+      logger.log('🔍 All storage keys:', allKeys);
       
       // Filter to transcript keys only
       const transcriptKeys = allKeys.filter(k => k.startsWith('transcript-'));
-      console.log('🔍 Transcript keys only:', transcriptKeys);
+      logger.log('🔍 Transcript keys only:', transcriptKeys);
       
     } catch (error) {
-      console.error('❌ Debug storage failed:', error);
+      logger.error('❌ Debug storage failed:', error);
     }
   }
 
@@ -35,29 +36,29 @@ export class TranscriptService {
     const retryDelay = 200;
     
     // 📦 Log what we're storing before save
-    console.log('📦 Storing transcript:');
-    console.log('📦 Transcript ID:', transcriptId);
-    console.log('📦 Data type:', typeof data);
-    console.log('📦 Data keys:', data && typeof data === 'object' ? Object.keys(data) : 'Not an object');
+    logger.log('📦 Storing transcript:');
+    logger.log('📦 Transcript ID:', transcriptId);
+    logger.log('📦 Data type:', typeof data);
+    logger.log('📦 Data keys:', data && typeof data === 'object' ? Object.keys(data) : 'Not an object');
     
     if (data && typeof data === 'object') {
-      console.log('📦 Full text validation before store:');
-      console.log('  - Has fullText:', !!data.fullText);
-      console.log('  - FullText type:', typeof data.fullText);
+      logger.log('📦 Full text validation before store:');
+      logger.log('  - Has fullText:', !!data.fullText);
+      logger.log('  - FullText type:', typeof data.fullText);
       if (typeof data.fullText === 'string') {
-        console.log('  - FullText length:', data.fullText.length);
-        console.log('  - FullText preview:', data.fullText.substring(0, 100) + '...');
+        logger.log('  - FullText length:', data.fullText.length);
+        logger.log('  - FullText preview:', data.fullText.substring(0, 100) + '...');
       }
       
-      console.log('📦 Segments validation before store:');
-      console.log('  - Has segments:', !!data.segments);
-      console.log('  - Segments is array:', Array.isArray(data.segments));
+      logger.log('📦 Segments validation before store:');
+      logger.log('  - Has segments:', !!data.segments);
+      logger.log('  - Segments is array:', Array.isArray(data.segments));
       if (Array.isArray(data.segments)) {
-        console.log('  - Segments count:', data.segments.length);
+        logger.log('  - Segments count:', data.segments.length);
         if (data.segments.length > 0) {
-          console.log('  - First 2 segments preview:');
+          logger.log('  - First 2 segments preview:');
           data.segments.slice(0, 2).forEach((seg, index) => {
-            console.log(`    → Segment ${index}: ${seg?.text || 'No text'}`);
+            logger.log(`    → Segment ${index}: ${seg?.text || 'No text'}`);
           });
         }
       }
@@ -65,9 +66,9 @@ export class TranscriptService {
     
     for (let attempt = 1; attempt <= maxRetries; attempt++) {
       try {
-        console.log(`📥 Storage attempt ${attempt}/${maxRetries} for transcript:`, transcriptId);
-        console.log('📌 Exact storage key:', `transcript-${transcriptId}`);
-        console.log('💾 Data being stored (truncated):', {
+        logger.log(`📥 Storage attempt ${attempt}/${maxRetries} for transcript:`, transcriptId);
+        logger.log('📌 Exact storage key:', `transcript-${transcriptId}`);
+        logger.log('💾 Data being stored (truncated):', {
           type: typeof data,
           keys: data && typeof data === 'object' ? Object.keys(data) : 'Not an object',
           textLength: data && data.fullText && typeof data.fullText === 'string' ? data.fullText.length : 'No valid fullText',
@@ -76,19 +77,19 @@ export class TranscriptService {
         
         // Store the transcript
         await StorageService.setItem(`transcript-${transcriptId}`, JSON.stringify(data));
-        console.log(`✅ AsyncStorage.setItem completed for attempt ${attempt}`);
+        logger.log(`✅ AsyncStorage.setItem completed for attempt ${attempt}`);
         
         // Small delay to ensure storage is committed
         await new Promise(resolve => setTimeout(resolve, 50));
         
         // Verify storage immediately
-        console.log(`🔍 Verifying storage for attempt ${attempt}...`);
-        console.log('📌 Verification key:', `transcript-${transcriptId}`);
+        logger.log(`🔍 Verifying storage for attempt ${attempt}...`);
+        logger.log('📌 Verification key:', `transcript-${transcriptId}`);
         
         const storedValue = await StorageService.getItem(`transcript-${transcriptId}`);
         const exists = storedValue !== null;
         
-        console.log(`🔍 Verification result for attempt ${attempt}:`, {
+        logger.log(`🔍 Verification result for attempt ${attempt}:`, {
           exists,
           storedValueType: typeof storedValue,
           storedValueLength: storedValue && typeof storedValue === 'string' ? storedValue.length : 'Not a string',
@@ -96,31 +97,31 @@ export class TranscriptService {
         });
         
         if (exists) {
-          console.log(`✅ Storage verification successful on attempt ${attempt}`);
+          logger.log(`✅ Storage verification successful on attempt ${attempt}`);
           return true;
         } else {
-          console.warn(`⚠️ Storage verification failed on attempt ${attempt} - stored value is null`);
+          logger.warn(`⚠️ Storage verification failed on attempt ${attempt} - stored value is null`);
           
           if (attempt < maxRetries) {
-            console.log(`🔁 Retrying in ${retryDelay}ms...`);
+            logger.log(`🔁 Retrying in ${retryDelay}ms...`);
             await new Promise(resolve => setTimeout(resolve, retryDelay));
           }
         }
         
       } catch (error) {
-        console.error(`❌ Storage attempt ${attempt} failed:`, error);
+        logger.error(`❌ Storage attempt ${attempt} failed:`, error);
         
         if (attempt < maxRetries) {
-          console.log(`🔁 Retrying in ${retryDelay}ms...`);
+          logger.log(`🔁 Retrying in ${retryDelay}ms...`);
           await new Promise(resolve => setTimeout(resolve, retryDelay));
         } else {
-          console.error(`❌ All ${maxRetries} storage attempts failed`);
+          logger.error(`❌ All ${maxRetries} storage attempts failed`);
           return false;
         }
       }
     }
     
-    console.error(`❌ Storage verification failed after ${maxRetries} attempts`);
+    logger.error(`❌ Storage verification failed after ${maxRetries} attempts`);
     return false;
   }
 
@@ -128,7 +129,7 @@ export class TranscriptService {
     try {
       return await this.storeTranscriptWithVerification(transcriptId, data);
     } catch (error) {
-      console.error('❌ Failed to store transcript:', error);
+      logger.error('❌ Failed to store transcript:', error);
       return false;
     }
   }
@@ -138,75 +139,75 @@ export class TranscriptService {
       const data = await StorageService.getItem(this.STORAGE_KEY);
       return data ? JSON.parse(data) : [];
     } catch (error) {
-      console.error('Error loading transcripts:', error);
+      logger.error('Error loading transcripts:', error);
       return [];
     }
   }
 
   static async getTranscriptByFileId(fileId: string): Promise<Transcript | null> {
-    console.log('🔍 getTranscriptByFileId called with fileId:', fileId);
-    console.log('🔑 Will use storage key:', `transcript-${fileId}`);
+    logger.log('🔍 getTranscriptByFileId called with fileId:', fileId);
+    logger.log('🔑 Will use storage key:', `transcript-${fileId}`);
     
     try {
       const storageKey = `transcript-${fileId}`;
-      console.log('🔍 Attempting to retrieve with key:', storageKey);
+      logger.log('🔍 Attempting to retrieve with key:', storageKey);
       
       const storedValue = await StorageService.getItem(storageKey);
-      console.log('🔍 Retrieved value exists:', storedValue !== null);
+      logger.log('🔍 Retrieved value exists:', storedValue !== null);
       
       if (!storedValue) {
-        console.log('❌ No stored value found for key:', storageKey);
+        logger.log('❌ No stored value found for key:', storageKey);
         
         // Debug: show all keys for comparison
         const allKeys = await StorageService.getAllKeys();
-        console.log('🔍 All storage keys:', allKeys);
+        logger.log('🔍 All storage keys:', allKeys);
         
         const transcriptKeys = allKeys.filter(k => k.startsWith('transcript-'));
-        console.log('🔍 Transcript keys only:', transcriptKeys);
+        logger.log('🔍 Transcript keys only:', transcriptKeys);
         
         return null;
       }
       
       // 📤 Log what we retrieved after successful fetch
-      console.log('📤 Retrieved transcript from storage:');
-      console.log('📤 Storage key used:', storageKey);
-      console.log('📤 Raw stored value length:', typeof storedValue === 'string' ? storedValue.length : 'Not a string');
+      logger.log('📤 Retrieved transcript from storage:');
+      logger.log('📤 Storage key used:', storageKey);
+      logger.log('📤 Raw stored value length:', typeof storedValue === 'string' ? storedValue.length : 'Not a string');
       
-      console.log('✅ Found stored transcript, parsing...');
+      logger.log('✅ Found stored transcript, parsing...');
       const transcript = JSON.parse(storedValue);
       
       // 📤 Validate retrieved transcript structure
-      console.log('📤 Retrieved transcript validation:');
-      console.log('  - Has id:', !!transcript?.id);
-      console.log('  - Has fileId:', !!transcript?.fileId);
-      console.log('  - Has fullText:', !!transcript?.fullText);
-      console.log('  - FullText type:', typeof transcript?.fullText);
+      logger.log('📤 Retrieved transcript validation:');
+      logger.log('  - Has id:', !!transcript?.id);
+      logger.log('  - Has fileId:', !!transcript?.fileId);
+      logger.log('  - Has fullText:', !!transcript?.fullText);
+      logger.log('  - FullText type:', typeof transcript?.fullText);
       if (typeof transcript?.fullText === 'string') {
-        console.log('  - FullText length:', transcript.fullText.length);
-        console.log('  - FullText preview:', transcript.fullText.substring(0, 100) + '...');
+        logger.log('  - FullText length:', transcript.fullText.length);
+        logger.log('  - FullText preview:', transcript.fullText.substring(0, 100) + '...');
       }
       
-      console.log('  - Has segments:', !!transcript?.segments);
-      console.log('  - Segments is array:', Array.isArray(transcript?.segments));
+      logger.log('  - Has segments:', !!transcript?.segments);
+      logger.log('  - Segments is array:', Array.isArray(transcript?.segments));
       if (Array.isArray(transcript?.segments)) {
-        console.log('  - Segments count:', transcript.segments.length);
+        logger.log('  - Segments count:', transcript.segments.length);
         if (transcript.segments.length > 0) {
-          console.log('  - First segment text:', transcript.segments[0]?.text || 'No text');
+          logger.log('  - First segment text:', transcript.segments[0]?.text || 'No text');
         }
       }
       
       // 🔍 Validate segments are not null/empty
       if (!transcript?.segments || !Array.isArray(transcript.segments)) {
-        console.log('⚠️ Retrieved transcript segments are null or missing.');
+        logger.log('⚠️ Retrieved transcript segments are null or missing.');
       } else {
         const validSegments = transcript.segments.filter(s => s && typeof s.text === 'string' && s.text.trim().length > 0);
-        console.log('✅ Valid segments count:', validSegments.length);
+        logger.log('✅ Valid segments count:', validSegments.length);
         if (validSegments.length !== transcript.segments.length) {
-          console.log('⚠️ Some segments have invalid text');
+          logger.log('⚠️ Some segments have invalid text');
         }
       }
       
-      console.log('✅ Transcript parsed successfully:', {
+      logger.log('✅ Transcript parsed successfully:', {
         id: transcript?.id,
         fileId: transcript?.fileId,
         hasSegments: Array.isArray(transcript?.segments),
@@ -217,7 +218,7 @@ export class TranscriptService {
       
       return transcript;
     } catch (error) {
-      console.error('❌ Error getting transcript by file ID:', error);
+      logger.error('❌ Error getting transcript by file ID:', error);
       return null;
     }
   }
@@ -235,7 +236,7 @@ export class TranscriptService {
       
       await StorageService.setItem(this.STORAGE_KEY, JSON.stringify(transcripts));
     } catch (error) {
-      console.error('Error saving transcript:', error);
+      logger.error('Error saving transcript:', error);
       throw error;
     }
   }
@@ -246,7 +247,7 @@ export class TranscriptService {
       const filtered = transcripts.filter(t => t.id !== transcriptId);
       await StorageService.setItem(this.STORAGE_KEY, JSON.stringify(filtered));
     } catch (error) {
-      console.error('Error deleting transcript:', error);
+      logger.error('Error deleting transcript:', error);
       throw error;
     }
   }
@@ -258,7 +259,7 @@ export class TranscriptService {
     language: string,
     duration: number
   ): Promise<Transcript> {
-    console.log('🔍 createTranscriptFromWhisper called with:', {
+    logger.log('🔍 createTranscriptFromWhisper called with:', {
       fileId,
       segments: {
         exists: !!segments,
@@ -279,13 +280,13 @@ export class TranscriptService {
     let processedSegments: TranscriptSegment[] = [];
     
     try {
-      console.log('🔍 About to process segments...');
+      logger.log('🔍 About to process segments...');
       
       if (segments && Array.isArray(segments)) {
-        console.log('🔍 Segments validation passed, length:', segments.length);
+        logger.log('🔍 Segments validation passed, length:', segments.length);
         
         processedSegments = segments.map((segment, index) => {
-          console.log(`🔍 Processing segment ${index}:`, {
+          logger.log(`🔍 Processing segment ${index}:`, {
             segment,
             hasText: segment && typeof segment.text === 'string',
             textLength: segment && segment.text && typeof segment.text === 'string' ? segment.text.length : 'No valid text'
@@ -299,15 +300,15 @@ export class TranscriptService {
           };
         });
         
-        console.log('🔍 Segments processed successfully:', {
+        logger.log('🔍 Segments processed successfully:', {
           processedCount: Array.isArray(processedSegments) ? processedSegments.length : 'Not an array'
         });
       } else {
-        console.warn('⚠️ No valid segments array provided, using empty array');
+        logger.warn('⚠️ No valid segments array provided, using empty array');
         processedSegments = [];
       }
     } catch (segmentError) {
-      console.error('❌ Error processing segments:', segmentError);
+      logger.error('❌ Error processing segments:', segmentError);
       processedSegments = [];
     }
 
@@ -321,7 +322,7 @@ export class TranscriptService {
       createdAt: new Date().toISOString(),
     };
 
-    console.log('🔍 About to save transcript:', {
+    logger.log('🔍 About to save transcript:', {
       transcriptId: transcript.id,
       fileId: transcript.fileId,
       segmentsCount: Array.isArray(transcript.segments) ? transcript.segments.length : 'Not an array',
@@ -330,13 +331,13 @@ export class TranscriptService {
     });
 
     // Store using the fileId as the key for consistency
-    console.log('💾 About to store transcript with fileId:', transcript.fileId);
+    logger.log('💾 About to store transcript with fileId:', transcript.fileId);
     const stored = await this.storeTranscript(transcript.fileId, transcript);
     if (!stored) {
       throw new Error('Failed to store transcript after multiple attempts');
     }
     
-    console.log('✅ Transcript created and stored successfully for fileId:', transcript.fileId);
+    logger.log('✅ Transcript created and stored successfully for fileId:', transcript.fileId);
     
     return transcript;
   }
@@ -346,7 +347,7 @@ export class TranscriptService {
     segmentId: string,
     newText: string
   ): Promise<void> {
-    console.log('🔍 updateTranscriptSegment called:', {
+    logger.log('🔍 updateTranscriptSegment called:', {
       transcriptId,
       segmentId,
       newText: {
@@ -358,7 +359,7 @@ export class TranscriptService {
 
     try {
       const transcripts = await this.getAllTranscripts();
-      console.log('🔍 Loaded transcripts:', {
+      logger.log('🔍 Loaded transcripts:', {
         exists: !!transcripts,
         isArray: Array.isArray(transcripts),
         length: Array.isArray(transcripts) ? transcripts.length : 'Not an array'
@@ -370,7 +371,7 @@ export class TranscriptService {
         throw new Error('Transcript not found');
       }
 
-      console.log('🔍 Found transcript:', {
+      logger.log('🔍 Found transcript:', {
         id: transcript.id,
         segmentsExists: !!transcript.segments,
         segmentsIsArray: Array.isArray(transcript.segments),
@@ -385,14 +386,14 @@ export class TranscriptService {
       segment.text = newText;
       
       // Regenerate full text from all segments
-      console.log('🔍 About to regenerate full text from segments...');
+      logger.log('🔍 About to regenerate full text from segments...');
       
       if (transcript.segments && Array.isArray(transcript.segments)) {
-        console.log('🔍 Segments validation passed for full text generation, length:', transcript.segments.length);
+        logger.log('🔍 Segments validation passed for full text generation, length:', transcript.segments.length);
         
         try {
           const textParts = transcript.segments.map((s, index) => {
-            console.log(`🔍 Processing segment ${index} for full text:`, {
+            logger.log(`🔍 Processing segment ${index} for full text:`, {
               segmentId: s?.id,
               hasText: s && typeof s.text === 'string',
               textLength: s && s.text && typeof s.text === 'string' ? s.text.length : 'No valid text'
@@ -401,74 +402,74 @@ export class TranscriptService {
             return s && s.text && typeof s.text === 'string' ? s.text : '';
           });
           
-          console.log('🔍 Text parts generated:', {
+          logger.log('🔍 Text parts generated:', {
             partsCount: Array.isArray(textParts) ? textParts.length : 'Not an array'
           });
           
           if (Array.isArray(textParts)) {
             transcript.fullText = textParts.join(' ');
-            console.log('🔍 Full text regenerated successfully, length:', 
+            logger.log('🔍 Full text regenerated successfully, length:', 
               typeof transcript.fullText === 'string' ? transcript.fullText.length : 'Not a string'
             );
           } else {
-            console.warn('⚠️ Text parts is not an array, keeping original full text');
+            logger.warn('⚠️ Text parts is not an array, keeping original full text');
           }
         } catch (fullTextError) {
-          console.error('❌ Error regenerating full text:', fullTextError);
+          logger.error('❌ Error regenerating full text:', fullTextError);
           // Keep original full text on error
         }
       } else {
-        console.warn('⚠️ No valid segments for full text regeneration');
+        logger.warn('⚠️ No valid segments for full text regeneration');
       }
 
       await this.saveTranscript(transcript);
     } catch (error) {
-      console.error('Error updating transcript segment:', error);
+      logger.error('Error updating transcript segment:', error);
       throw error;
     }
   }
   static async hasTranscript(fileId: string): Promise<boolean> {
-    console.log('🔍 hasTranscript called for fileId:', fileId);
+    logger.log('🔍 hasTranscript called for fileId:', fileId);
     
     try {
       const storageKey = `transcript-${fileId}`;
-      console.log('🔑 hasTranscript storage key:', storageKey);
+      logger.log('🔑 hasTranscript storage key:', storageKey);
       
       const stored = await StorageService.getItem(storageKey);
       const exists = stored !== null;
-      console.log(`🔍 hasTranscript result: ${fileId} = ${exists}`);
+      logger.log(`🔍 hasTranscript result: ${fileId} = ${exists}`);
       
       if (!exists) {
         // Debug: show what keys do exist
         const allKeys = await StorageService.getAllKeys();
         const transcriptKeys = allKeys.filter(k => k.startsWith('transcript-'));
-        console.log('🔍 hasTranscript - available transcript keys:', transcriptKeys);
+        logger.log('🔍 hasTranscript - available transcript keys:', transcriptKeys);
       }
       
       return exists;
     } catch (error) {
-      console.error('❌ hasTranscript failed for fileId:', fileId, 'Error:', error);
+      logger.error('❌ hasTranscript failed for fileId:', fileId, 'Error:', error);
       return false;
     }
   }
 
   static async deleteTranscriptByFileId(fileId: string): Promise<void> {
-    console.log('🗑️ deleteTranscriptByFileId called for fileId:', fileId);
+    logger.log('🗑️ deleteTranscriptByFileId called for fileId:', fileId);
     
     try {
       const storageKey = `transcript-${fileId}`;
-      console.log('🔑 Deleting transcript with key:', storageKey);
+      logger.log('🔑 Deleting transcript with key:', storageKey);
       
       await StorageService.removeItem(storageKey);
-      console.log('✅ Transcript deleted successfully');
+      logger.log('✅ Transcript deleted successfully');
     } catch (error) {
-      console.error('❌ Error deleting transcript:', error);
+      logger.error('❌ Error deleting transcript:', error);
       throw new Error('Failed to delete transcription');
     }
   }
 
   static async updateTranscript(transcript: Transcript): Promise<void> {
-    console.log('🔍 updateTranscript called:', {
+    logger.log('🔍 updateTranscript called:', {
       transcriptId: transcript?.id,
       segmentsExists: !!transcript?.segments,
       segmentsIsArray: Array.isArray(transcript?.segments),
@@ -477,9 +478,9 @@ export class TranscriptService {
     
     try {
       await this.saveTranscript(transcript);
-      console.log('✅ Transcript updated successfully');
+      logger.log('✅ Transcript updated successfully');
     } catch (error) {
-      console.error('❌ Error updating transcript:', error);
+      logger.error('❌ Error updating transcript:', error);
       throw error;
     }
   }

--- a/utils/logger.ts
+++ b/utils/logger.ts
@@ -1,0 +1,21 @@
+const isDev = typeof __DEV__ !== 'undefined' ? __DEV__ : process.env.NODE_ENV !== 'production';
+const debugFlag = process.env.EXPO_PUBLIC_DEBUG?.toLowerCase() === 'true';
+const enableDebug = isDev || debugFlag;
+
+const logger = {
+  log: (...args: any[]) => {
+    if (enableDebug) {
+      console.log(...args);
+    }
+  },
+  warn: (...args: any[]) => {
+    if (enableDebug) {
+      console.warn(...args);
+    }
+  },
+  error: (...args: any[]) => {
+    console.error(...args);
+  },
+};
+
+export default logger;


### PR DESCRIPTION
## Summary
- add environment-aware logger utility
- refactor services, hooks and app modules to use centralized logger
- remove non-essential playback debug logs

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: ESLint couldn't find a config file)


------
https://chatgpt.com/codex/tasks/task_e_689a5dc3ebb4832b8cbf04cc77714d45