### PR TITLE
refactor: add interfaces for transcripts and store events

### DIFF
--- a/context/FolderExplorerContext.tsx
+++ b/context/FolderExplorerContext.tsx
@@ -1,7 +1,7 @@
 import React, { createContext, useContext, ReactNode } from 'react';
 import { useState, useEffect, useCallback, useRef } from 'react';
-import { Folder } from '@/types/folder';
-import { FoldersAdapter, FolderEvent, FolderWithCounts } from '@/services/foldersAdapter';
+import { Folder, FolderEvent } from '@/types/folder';
+import { FoldersAdapter, FolderWithCounts } from '@/services/foldersAdapter';
 
 interface OptimisticFolder extends Folder {
   tempId: string;

--- a/data/recordingsStore.ts
+++ b/data/recordingsStore.ts
@@ -2,6 +2,7 @@ import { Platform } from 'react-native';
 import { AudioFile } from '@/types/audio';
 import { Tag } from '@/types/tag';
 import { Folder } from '@/types/folder';
+import { StoreEvent } from '@/types/store';
 import { AudioStorageService } from '@/services/audioStorage';
 import { FolderService } from '@/services/folderService';
 import { StorageService } from '@/services/storageService';
@@ -11,7 +12,7 @@ const TAGS_KEY = 'rg.tags.v1';
 
 // Store change listeners
 type StoreChangeListener = () => void;
-type StoreChangeListenerWithEvent = (event?: any) => void;
+type StoreChangeListenerWithEvent<T extends StoreEvent = StoreEvent> = (event?: T) => void;
 const storeChangeListeners: StoreChangeListener[] = [];
 const storeChangeListenersWithEvent: StoreChangeListenerWithEvent[] = [];
 
@@ -42,7 +43,7 @@ export class RecordingsStore {
     return Date.now().toString() + '_' + Math.random().toString(36).substring(2, 15);
   }
 
-  static notifyStoreChanged(fromBroadcast: boolean = false, event?: any): void {
+  static notifyStoreChanged(fromBroadcast: boolean = false, event?: StoreEvent): void {
     // Broadcast to other tabs/windows on web platform
     if (Platform.OS === 'web' && typeof window !== 'undefined' && typeof window.BroadcastChannel !== 'undefined' && !fromBroadcast && syncChannel && event) {
       try {
@@ -71,10 +72,10 @@ export class RecordingsStore {
     };
   }
 
-  static addStoreChangeListenerWithEvent(listener: StoreChangeListenerWithEvent): () => void {
-    storeChangeListenersWithEvent.push(listener);
+  static addStoreChangeListenerWithEvent<T extends StoreEvent>(listener: StoreChangeListenerWithEvent<T>): () => void {
+    storeChangeListenersWithEvent.push(listener as StoreChangeListenerWithEvent);
     return () => {
-      const index = storeChangeListenersWithEvent.indexOf(listener);
+      const index = storeChangeListenersWithEvent.indexOf(listener as StoreChangeListenerWithEvent);
       if (index > -1) {
         storeChangeListenersWithEvent.splice(index, 1);
       }

--- a/hooks/useFolderChildren.ts
+++ b/hooks/useFolderChildren.ts
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
-import { Folder } from '@/types/folder';
-import { FoldersAdapter, FolderEvent, FolderWithCounts } from '@/services/foldersAdapter';
+import { Folder, FolderEvent } from '@/types/folder';
+import { FoldersAdapter, FolderWithCounts } from '@/services/foldersAdapter';
 
 interface OptimisticFolder extends Folder {
   tempId: string;

--- a/hooks/useFolders.ts
+++ b/hooks/useFolders.ts
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback } from 'react';
-import { Folder, FolderFilter } from '@/types/folder';
-import { FoldersAdapter, FolderWithCounts, FolderEvent } from '@/services/foldersAdapter';
+import { Folder, FolderEvent, FolderFilter } from '@/types/folder';
+import { FoldersAdapter, FolderWithCounts } from '@/services/foldersAdapter';
 
 export function useFolders() {
   const [folders, setFolders] = useState<FolderWithCounts[]>([]);

--- a/services/foldersAdapter.ts
+++ b/services/foldersAdapter.ts
@@ -1,17 +1,6 @@
-import { Folder } from '@/types/folder';
+import { Folder, FolderEvent } from '@/types/folder';
 import { RecordingsStore } from '@/data/recordingsStore';
 import { FolderService } from '@/services/folderService';
-
-export interface FolderEvent {
-  type: 'folders_changed';
-  payload: {
-    op: 'create' | 'rename' | 'move' | 'delete';
-    id: string;
-    parentId?: string | null;
-    timestamp: number;
-    version: number;
-  };
-}
 
 export interface FolderWithCounts extends Folder {
   subfolderCount: number;
@@ -299,5 +288,3 @@ export class FoldersAdapter {
     }
   }
 }
-
-export { FoldersAdapter }

--- a/services/transcriptService.ts
+++ b/services/transcriptService.ts
@@ -30,7 +30,7 @@ export class TranscriptService {
     }
   }
 
-  static async storeTranscriptWithVerification(transcriptId: string, data: any): Promise<boolean> {
+  static async storeTranscriptWithVerification(transcriptId: string, data: Transcript): Promise<boolean> {
     const maxRetries = 3;
     const retryDelay = 200;
     
@@ -124,7 +124,7 @@ export class TranscriptService {
     return false;
   }
 
-  static async storeTranscript(transcriptId: string, data: any): Promise<boolean> {
+  static async storeTranscript(transcriptId: string, data: Transcript): Promise<boolean> {
     try {
       return await this.storeTranscriptWithVerification(transcriptId, data);
     } catch (error) {
@@ -199,7 +199,9 @@ export class TranscriptService {
       if (!transcript?.segments || !Array.isArray(transcript.segments)) {
         console.log('⚠️ Retrieved transcript segments are null or missing.');
       } else {
-        const validSegments = transcript.segments.filter(s => s && typeof s.text === 'string' && s.text.trim().length > 0);
+        const validSegments = transcript.segments.filter(
+          (s: TranscriptSegment) => s && typeof s.text === 'string' && s.text.trim().length > 0
+        );
         console.log('✅ Valid segments count:', validSegments.length);
         if (validSegments.length !== transcript.segments.length) {
           console.log('⚠️ Some segments have invalid text');

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "expo/tsconfig.base",
   "compilerOptions": {
     "strict": true,
+    "noImplicitAny": true,
     "paths": {
       "@/*": ["./*"]
     }

--- a/types/folder.ts
+++ b/types/folder.ts
@@ -1,3 +1,5 @@
+import { StoreEvent } from './store';
+
 export interface Folder {
   id: string;
   name: string;
@@ -13,16 +15,18 @@ export interface FolderFilter {
   folderName: string | null;
 }
 
-export interface FolderEvent {
+export interface FolderEventPayload {
+  op?: 'create' | 'rename' | 'move' | 'delete'; // Made optional for local_reconcile
+  id?: string; // Made optional for local_reconcile
+  parentId?: string | null;
+  name?: string; // Made optional for local_reconcile
+  timestamp: number;
+  version?: number; // Made optional as local_reconcile might not have it
+  tempId?: string; // New field for folders_local_reconcile
+  real?: Folder; // New field for folders_local_reconcile
+}
+
+export interface FolderEvent extends StoreEvent<FolderEventPayload> {
   type: 'folders_changed' | 'folders_local_reconcile';
-  payload: {
-    op?: 'create' | 'rename' | 'move' | 'delete'; // Made optional for local_reconcile
-    id?: string; // Made optional for local_reconcile
-    parentId?: string | null;
-    name?: string; // Made optional for local_reconcile
-    timestamp: number;
-    version?: number; // Made optional as local_reconcile might not have it
-    tempId?: string; // New field for folders_local_reconcile
-    real?: Folder; // New field for folders_local_reconcile
-  };
+  payload: FolderEventPayload;
 }

--- a/types/store.ts
+++ b/types/store.ts
@@ -1,0 +1,4 @@
+export interface StoreEvent<T = unknown> {
+  type: string;
+  payload?: T;
+}

--- a/types/transcript.ts
+++ b/types/transcript.ts
@@ -6,13 +6,16 @@ export interface TranscriptSegment {
   confidence?: number;
 }
 
-export interface Transcript {
-  id: string;
-  fileId: string;
+export interface TranscriptPayload {
   segments: TranscriptSegment[];
   fullText: string;
   language?: string;
   duration?: number;
+}
+
+export interface Transcript extends TranscriptPayload {
+  id: string;
+  fileId: string;
   createdAt: string;
 }
 


### PR DESCRIPTION
## Summary
- add TranscriptPayload interface and type transcript storage methods
- introduce generic StoreEvent and use it in RecordingsStore
- enable `noImplicitAny` for stronger type checking

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: ESLint couldn't find a config file)*
- `npx tsc -p tsconfig.json --noEmit` *(fails: numerous type errors in existing code)*

------
https://chatgpt.com/codex/tasks/task_e_689a5dc53e10832b84a7c38d40094e58