### PR TITLE
refactor: type transcript and store events

### DIFF
--- a/context/FolderExplorerContext.tsx
+++ b/context/FolderExplorerContext.tsx
@@ -1,7 +1,8 @@
 import React, { createContext, useContext, ReactNode } from 'react';
 import { useState, useEffect, useCallback, useRef } from 'react';
 import { Folder } from '@/types/folder';
-import { FoldersAdapter, FolderEvent, FolderWithCounts } from '@/services/foldersAdapter';
+import { FoldersAdapter, FolderWithCounts } from '@/services/foldersAdapter';
+import { FolderEvent } from '@/types/folder';
 
 interface OptimisticFolder extends Folder {
   tempId: string;
@@ -240,7 +241,7 @@ export function FolderExplorerProvider({ parentId, children }: FolderExplorerPro
 
     if (affectsCurrentParent) {
       console.log('🎯 FolderExplorerProvider: Event affects current parent');
-      if (op === 'delete' && eventParentId === parentId) {
+      if (op === 'delete' && id && eventParentId === parentId) {
         setItems(prev => prev.filter(item => !('id' in item && item.id === id)));
         pendingDeletedIds.current.add(id);
         debouncedRefetch();

--- a/data/recordingsStore.ts
+++ b/data/recordingsStore.ts
@@ -2,6 +2,7 @@ import { Platform } from 'react-native';
 import { AudioFile } from '@/types/audio';
 import { Tag } from '@/types/tag';
 import { Folder } from '@/types/folder';
+import { StoreEvent } from '@/types/store';
 import { AudioStorageService } from '@/services/audioStorage';
 import { FolderService } from '@/services/folderService';
 import { StorageService } from '@/services/storageService';
@@ -11,7 +12,7 @@ const TAGS_KEY = 'rg.tags.v1';
 
 // Store change listeners
 type StoreChangeListener = () => void;
-type StoreChangeListenerWithEvent = (event?: any) => void;
+type StoreChangeListenerWithEvent = (event?: StoreEvent) => void;
 const storeChangeListeners: StoreChangeListener[] = [];
 const storeChangeListenersWithEvent: StoreChangeListenerWithEvent[] = [];
 
@@ -42,7 +43,7 @@ export class RecordingsStore {
     return Date.now().toString() + '_' + Math.random().toString(36).substring(2, 15);
   }
 
-  static notifyStoreChanged(fromBroadcast: boolean = false, event?: any): void {
+  static notifyStoreChanged(fromBroadcast: boolean = false, event?: StoreEvent): void {
     // Broadcast to other tabs/windows on web platform
     if (Platform.OS === 'web' && typeof window !== 'undefined' && typeof window.BroadcastChannel !== 'undefined' && !fromBroadcast && syncChannel && event) {
       try {
@@ -100,7 +101,7 @@ export class RecordingsStore {
 
   static async moveRecordingToFolder(recordingId: string, folderId: string | null): Promise<AudioFile | null> {
     try {
-      const updatedRecording = await AudioStorageService.updateAudioFile(recordingId, { folderId });
+      const updatedRecording = await AudioStorageService.updateAudioFile(recordingId, { folderId: folderId ?? undefined });
       if (!updatedRecording) {
         throw new Error('Recording not found');
       }
@@ -320,7 +321,7 @@ export class RecordingsStore {
       // Update each recording individually
       for (const recording of updatedRecordings) {
         if (recording.folderId !== recordings.find(r => r.id === recording.id)?.folderId) {
-          await AudioStorageService.updateAudioFile(recording.id, { folderId: recording.folderId });
+          await AudioStorageService.updateAudioFile(recording.id, { folderId: recording.folderId ?? undefined });
         }
       }
 

--- a/hooks/useFolderChildren.ts
+++ b/hooks/useFolderChildren.ts
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
-import { Folder } from '@/types/folder';
-import { FoldersAdapter, FolderEvent, FolderWithCounts } from '@/services/foldersAdapter';
+import { Folder, FolderEvent } from '@/types/folder';
+import { FoldersAdapter, FolderWithCounts } from '@/services/foldersAdapter';
 import logger from '@/utils/logger';
 
 interface OptimisticFolder extends Folder {

--- a/hooks/useFolders.ts
+++ b/hooks/useFolders.ts
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback } from 'react';
-import { Folder, FolderFilter } from '@/types/folder';
-import { FoldersAdapter, FolderWithCounts, FolderEvent } from '@/services/foldersAdapter';
+import { Folder, FolderFilter, FolderEvent } from '@/types/folder';
+import { FoldersAdapter, FolderWithCounts } from '@/services/foldersAdapter';
 import logger from '@/utils/logger';
 
 export function useFolders() {

--- a/services/foldersAdapter.ts
+++ b/services/foldersAdapter.ts
@@ -1,18 +1,8 @@
-import { Folder } from '@/types/folder';
+import { Folder, FolderEvent } from '@/types/folder';
+import { StoreEvent } from '@/types/store';
 import { RecordingsStore } from '@/data/recordingsStore';
 import { FolderService } from '@/services/folderService';
 import logger from '@/utils/logger';
-
-export interface FolderEvent {
-  type: 'folders_changed';
-  payload: {
-    op: 'create' | 'rename' | 'move' | 'delete';
-    id: string;
-    parentId?: string | null;
-    timestamp: number;
-    version: number;
-  };
-}
 
 export interface FolderWithCounts extends Folder {
   subfolderCount: number;
@@ -49,8 +39,8 @@ export class FoldersAdapter {
       this.invalidateCache();
     });
     
-    RecordingsStore.addStoreChangeListenerWithEvent((event?: FolderEvent) => {
-      this.notifyListeners(event);
+    RecordingsStore.addStoreChangeListenerWithEvent((event?: StoreEvent) => {
+      this.notifyListeners(event as FolderEvent | undefined);
     });
   }
 
@@ -300,5 +290,3 @@ export class FoldersAdapter {
     }
   }
 }
-
-export { FoldersAdapter }

--- a/services/transcriptService.ts
+++ b/services/transcriptService.ts
@@ -1,4 +1,4 @@
-import { Transcript, TranscriptSegment } from '@/types/transcript';
+import { Transcript, TranscriptSegment, TranscriptSegmentPayload } from '@/types/transcript';
 import { StorageService } from './storageService';
 import logger from '@/utils/logger';
 
@@ -31,7 +31,7 @@ export class TranscriptService {
     }
   }
 
-  static async storeTranscriptWithVerification(transcriptId: string, data: any): Promise<boolean> {
+  static async storeTranscriptWithVerification(transcriptId: string, data: Transcript): Promise<boolean> {
     const maxRetries = 3;
     const retryDelay = 200;
     
@@ -125,7 +125,7 @@ export class TranscriptService {
     return false;
   }
 
-  static async storeTranscript(transcriptId: string, data: any): Promise<boolean> {
+  static async storeTranscript(transcriptId: string, data: Transcript): Promise<boolean> {
     try {
       return await this.storeTranscriptWithVerification(transcriptId, data);
     } catch (error) {
@@ -200,7 +200,7 @@ export class TranscriptService {
       if (!transcript?.segments || !Array.isArray(transcript.segments)) {
         logger.log('⚠️ Retrieved transcript segments are null or missing.');
       } else {
-        const validSegments = transcript.segments.filter(s => s && typeof s.text === 'string' && s.text.trim().length > 0);
+        const validSegments = transcript.segments.filter((s: TranscriptSegment) => s && typeof s.text === 'string' && s.text.trim().length > 0);
         logger.log('✅ Valid segments count:', validSegments.length);
         if (validSegments.length !== transcript.segments.length) {
           logger.log('⚠️ Some segments have invalid text');
@@ -254,7 +254,7 @@ export class TranscriptService {
 
   static async createTranscriptFromWhisper(
     fileId: string,
-    segments: any[],
+    segments: TranscriptSegmentPayload[],
     fullText: string,
     language: string,
     duration: number
@@ -285,7 +285,7 @@ export class TranscriptService {
       if (segments && Array.isArray(segments)) {
         logger.log('🔍 Segments validation passed, length:', segments.length);
         
-        processedSegments = segments.map((segment, index) => {
+        processedSegments = segments.map((segment: TranscriptSegmentPayload, index) => {
           logger.log(`🔍 Processing segment ${index}:`, {
             segment,
             hasText: segment && typeof segment.text === 'string',

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "expo/tsconfig.base",
   "compilerOptions": {
     "strict": true,
+    "noImplicitAny": true,
     "paths": {
       "@/*": [
         "./*"

--- a/types/folder.ts
+++ b/types/folder.ts
@@ -1,3 +1,5 @@
+import { StoreEvent } from './store';
+
 export interface Folder {
   id: string;
   name: string;
@@ -13,7 +15,7 @@ export interface FolderFilter {
   folderName: string | null;
 }
 
-export interface FolderEvent {
+export interface FolderEvent extends StoreEvent {
   type: 'folders_changed' | 'folders_local_reconcile';
   payload: {
     op?: 'create' | 'rename' | 'move' | 'delete'; // Made optional for local_reconcile

--- a/types/store.ts
+++ b/types/store.ts
@@ -1,0 +1,4 @@
+export interface StoreEvent<T extends string = string, P = unknown> {
+  type: T;
+  payload?: P;
+}

--- a/types/transcript.ts
+++ b/types/transcript.ts
@@ -6,6 +6,13 @@ export interface TranscriptSegment {
   confidence?: number;
 }
 
+export interface TranscriptSegmentPayload {
+  id: number | string;
+  start: number;
+  end: number;
+  text: string;
+}
+
 export interface Transcript {
   id: string;
   fileId: string;


### PR DESCRIPTION
## Summary
- add StoreEvent interface and extend FolderEvent typings
- use Transcript and StoreEvent types in TranscriptService and RecordingsStore
- enable noImplicitAny and adjust affected code

## Testing
- `npm run lint` *(fails: Cannot find module 'eslint')*
- `npx tsc --noEmit` *(fails: type errors in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_689a64be59f0832b866379e0602e13ae