### PR TITLE
Manage BroadcastChannel lifecycle for cross-tab sync

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -2,9 +2,18 @@ import { useEffect } from 'react';
 import { Stack } from 'expo-router';
 import { StatusBar } from 'expo-status-bar';
 import { useFrameworkReady } from '@/hooks/useFrameworkReady';
+import { RecordingsStore } from '@/data/recordingsStore';
 
 export default function RootLayout() {
   useFrameworkReady();
+
+  useEffect(() => {
+    const enabled = process.env.EXPO_PUBLIC_ENABLE_CROSS_TAB_SYNC !== 'false';
+    RecordingsStore.setCrossTabSyncEnabled(enabled);
+    return () => {
+      RecordingsStore.disableCrossTabSync();
+    };
+  }, []);
 
   return (
     <>


### PR DESCRIPTION
## Summary
- add explicit BroadcastChannel initialization with stored cleanup function
- expose methods to enable/disable cross-tab sync and document contract
- initialize and clean up cross-tab sync in app root

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Cannot find module 'eslint')*
- `npx tsc -p tsconfig.json --noEmit` *(fails: found 66 errors in 24 files)*

------
https://chatgpt.com/codex/tasks/task_e_689a5dc915ac832bb8bea2fb0aeb8694