### PR TITLE
Handle cross‑tab BroadcastChannel cleanup

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -2,9 +2,25 @@ import { useEffect } from 'react';
 import { Stack } from 'expo-router';
 import { StatusBar } from 'expo-status-bar';
 import { useFrameworkReady } from '@/hooks/useFrameworkReady';
+import { RecordingsStore } from '@/data/recordingsStore';
 
 export default function RootLayout() {
   useFrameworkReady();
+
+  useEffect(() => {
+    const disabled =
+      process.env.EXPO_PUBLIC_DISABLE_CROSS_TAB_SYNC?.toLowerCase() === 'true';
+
+    if (!disabled) {
+      RecordingsStore.initCrossTabSync();
+      return () => {
+        RecordingsStore.disableCrossTabSync();
+      };
+    }
+
+    // If disabled, ensure any existing channel is cleaned up
+    RecordingsStore.disableCrossTabSync();
+  }, []);
 
   return (
     <>


### PR DESCRIPTION
## Summary
- add explicit init/cleanup API for BroadcastChannel cross-tab syncing in RecordingsStore
- clean up sync channel when the app unmounts or cross-tab syncing disabled
- document initialization/cleanup contract for cross-tab sync

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a6cab393c832b8ac09e27fba9cf44