### PR TITLE
refactor: guard DOM access for native platforms

### DIFF
--- a/components/AudioPlayerModule.tsx
+++ b/components/AudioPlayerModule.tsx
@@ -1,5 +1,5 @@
 import React, { useState, forwardRef, useImperativeHandle, useRef, useEffect } from 'react';
-import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
+import { View, Text, StyleSheet, TouchableOpacity, Platform } from 'react-native';
 import { BlurView } from 'expo-blur';
 import { Play, Pause, SkipBack, SkipForward } from 'lucide-react-native';
 import { AudioPlayerState } from '@/types/transcript';
@@ -212,6 +212,8 @@ const AudioPlayerModule = forwardRef<AudioPlayerRef, AudioPlayerModuleProps>(({
 
   // Add global mouse up listener to handle mouse up outside the progress bar
   useEffect(() => {
+    if (Platform.OS !== 'web') return;
+
     if (isDragging) {
       const handleGlobalMouseUp = () => setIsDragging(false);
       const handleGlobalMouseMove = (event: MouseEvent) => {
@@ -223,17 +225,17 @@ const AudioPlayerModule = forwardRef<AudioPlayerRef, AudioPlayerModuleProps>(({
             const progressWidth = rect.width;
             const clickPercentage = clickX / progressWidth;
             const newTime = clickPercentage * playerState.duration;
-            
+
             audioRef.current.currentTime = newTime;
             setPlayerState(prev => ({ ...prev, currentTime: newTime }));
             onSeek?.(newTime);
           }
         }
       };
-      
+
       document.addEventListener('mouseup', handleGlobalMouseUp);
       document.addEventListener('mousemove', handleGlobalMouseMove);
-      
+
       return () => {
         document.removeEventListener('mouseup', handleGlobalMouseUp);
         document.removeEventListener('mousemove', handleGlobalMouseMove);

--- a/components/FileCard.tsx
+++ b/components/FileCard.tsx
@@ -502,11 +502,13 @@ export default function FileCard({
   };
 
   useEffect(() => {
+    if (Platform.OS !== 'web') return;
+
     if (isProgressDragging) {
       const handleGlobalMouseUp = () => {
         setIsProgressDragging(false);
       };
-      
+
       const handleGlobalMouseMove = (event: MouseEvent) => {
         if (isProgressDragging && file.duration) {
           const progressContainer = document.querySelector(`[data-progress-${file.id}]`);
@@ -516,16 +518,16 @@ export default function FileCard({
             const progressWidth = rect.width;
             const clickPercentage = clickX / progressWidth;
             const newTime = clickPercentage * file.duration;
-            
+
             setLocalCurrentTime(newTime);
             onSeek?.(file.id, newTime);
           }
         }
       };
-      
+
       document.addEventListener('mouseup', handleGlobalMouseUp);
       document.addEventListener('mousemove', handleGlobalMouseMove);
-      
+
       return () => {
         document.removeEventListener('mouseup', handleGlobalMouseUp);
         document.removeEventListener('mousemove', handleGlobalMouseMove);

--- a/hooks/useFrameworkReady.ts
+++ b/hooks/useFrameworkReady.ts
@@ -1,4 +1,5 @@
 import { useEffect } from 'react';
+import { Platform } from 'react-native';
 
 declare global {
   interface Window {
@@ -8,6 +9,8 @@ declare global {
 
 export function useFrameworkReady() {
   useEffect(() => {
-    window.frameworkReady?.();
-  });
+    if (Platform.OS === 'web') {
+      window.frameworkReady?.();
+    }
+  }, []);
 }

--- a/hooks/useGlobalAudioManager.ts
+++ b/hooks/useGlobalAudioManager.ts
@@ -1,10 +1,11 @@
 import { useRef, useCallback } from 'react';
-import logger from '@/utils/logger';
+import { Platform } from 'react-native';
+import logger from '../utils/logger';
 
 // Global audio manager to ensure only one audio plays at a time
-class GlobalAudioManager {
+export class GlobalAudioManager {
   private static instance: GlobalAudioManager;
-  private currentAudio: HTMLAudioElement | null = null;
+  private currentAudio: any | null = null;
   private currentFileId: string | null = null;
 
   static getInstance(): GlobalAudioManager {
@@ -16,29 +17,37 @@ class GlobalAudioManager {
 
   stopAll(): void {
     logger.log('🛑 GlobalAudioManager: Stopping all audio');
-    
+
     // Stop our tracked audio
     if (this.currentAudio) {
       logger.log('  - Stopping tracked audio for file:', this.currentFileId);
-      this.currentAudio.pause();
-      this.currentAudio.currentTime = 0;
-    }
-    
-    // Stop ALL audio elements on the page
-    const allAudioElements = document.querySelectorAll('audio');
-    allAudioElements.forEach((audio, index) => {
-      if (!audio.paused) {
-        logger.log(`  - Force stopping audio element ${index + 1}`);
-        audio.pause();
-        audio.currentTime = 0;
+      if (typeof this.currentAudio.pause === 'function') {
+        this.currentAudio.pause();
       }
-    });
-    
+      if (typeof this.currentAudio.currentTime === 'number') {
+        this.currentAudio.currentTime = 0;
+      } else if (typeof this.currentAudio.setPositionAsync === 'function') {
+        this.currentAudio.setPositionAsync(0);
+      }
+    }
+
+    // Stop ALL audio elements on the page (web only)
+    if (Platform.OS === 'web' && typeof document !== 'undefined') {
+      const allAudioElements = document.querySelectorAll('audio');
+      allAudioElements.forEach((audio, index) => {
+        if (!audio.paused) {
+          logger.log(`  - Force stopping audio element ${index + 1}`);
+          audio.pause();
+          audio.currentTime = 0;
+        }
+      });
+    }
+
     this.currentAudio = null;
     this.currentFileId = null;
   }
 
-  setCurrentAudio(audio: HTMLAudioElement, fileId: string): void {
+  setCurrentAudio(audio: any, fileId: string): void {
     logger.log('🎵 GlobalAudioManager: Setting current audio for file:', fileId);
     
     // Stop any existing audio first
@@ -64,7 +73,7 @@ export function useGlobalAudioManager() {
     managerRef.current.stopAll();
   }, []);
 
-  const setCurrentAudio = useCallback((audio: HTMLAudioElement, fileId: string) => {
+  const setCurrentAudio = useCallback((audio: any, fileId: string) => {
     managerRef.current.setCurrentAudio(audio, fileId);
   }, []);
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dev": "EXPO_NO_TELEMETRY=1 expo start",
     "build:web": "expo export --platform web",
     "lint": "expo lint",
-    "test": "npx tsc services/storageService.ts --esModuleInterop --module commonjs --target ES2019 --skipLibCheck --outDir tests/temp && node --require ./tests/react-native-mock.js tests/storageService.web.test.js"
+    "test": "npx tsc services/storageService.ts hooks/useGlobalAudioManager.ts --esModuleInterop --module commonjs --target ES2019 --skipLibCheck --outDir tests/temp && node --require ./tests/react-native-mock.js tests/storageService.web.test.js && node --require ./tests/react-native-mock.js tests/globalAudioManager.test.js"
   },
   "dependencies": {
     "@expo/vector-icons": "^14.1.0",

--- a/tests/globalAudioManager.test.js
+++ b/tests/globalAudioManager.test.js
@@ -1,0 +1,59 @@
+const { Platform } = require('react-native');
+const { GlobalAudioManager } = require('./temp/hooks/useGlobalAudioManager.js');
+
+(function run() {
+  const manager = GlobalAudioManager.getInstance();
+
+  // Web scenario
+  Platform.OS = 'web';
+  let queryCalled = false;
+  global.document = {
+    querySelectorAll: () => {
+      queryCalled = true;
+      return [{
+        paused: false,
+        pause() {
+          this.paused = true;
+        },
+        currentTime: 10
+      }];
+    }
+  };
+  const webAudio = {
+    paused: false,
+    pause() {
+      this.paused = true;
+    },
+    currentTime: 5
+  };
+  manager.setCurrentAudio(webAudio, 'web-file');
+  manager.stopAll();
+  if (!queryCalled || !webAudio.paused || webAudio.currentTime !== 0) {
+    console.error('Web behavior failed');
+    process.exit(1);
+  }
+
+  // Native scenario
+  Platform.OS = 'ios';
+  delete global.document;
+  const nativeAudio = {
+    paused: false,
+    pause() {
+      this.paused = true;
+    },
+    currentTime: 7
+  };
+  manager.setCurrentAudio(nativeAudio, 'native-file');
+  try {
+    manager.stopAll();
+    if (!nativeAudio.paused || nativeAudio.currentTime !== 0) {
+      console.error('Native behavior failed');
+      process.exit(1);
+    }
+  } catch (err) {
+    console.error('Native behavior threw error', err);
+    process.exit(1);
+  }
+
+  console.log('GlobalAudioManager platform tests passed');
+})();


### PR DESCRIPTION
## Summary
- wrap document usage in platform checks for FileCard and AudioPlayerModule
- guard global framework and audio manager logic behind web checks
- add platform-aware unit test for GlobalAudioManager

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a6e3e3500832b949d6c78b5cc500a