### PR TITLE
Memoize FolderExplorer context value to avoid unnecessary re-renders

### DIFF
--- a/context/FolderExplorerContext.tsx
+++ b/context/FolderExplorerContext.tsx
@@ -1,5 +1,5 @@
 import React, { createContext, useContext, ReactNode } from 'react';
-import { useState, useEffect, useCallback, useRef } from 'react';
+import { useState, useEffect, useCallback, useRef, useMemo } from 'react';
 import { Folder } from '@/types/folder';
 import { FoldersAdapter, FolderWithCounts } from '@/services/foldersAdapter';
 import { FolderEvent } from '@/types/folder';
@@ -296,7 +296,7 @@ export function FolderExplorerProvider({ parentId, children }: FolderExplorerPro
     };
   }, []);
 
-  const contextValue: FolderExplorerContextType = {
+  const contextValue: FolderExplorerContextType = useMemo(() => ({
     parentId,
     items,
     loading,
@@ -305,7 +305,16 @@ export function FolderExplorerProvider({ parentId, children }: FolderExplorerPro
     addOptimisticFolder,
     replaceOptimisticFolder,
     removeOptimisticFolder,
-  };
+  }), [
+    parentId,
+    items,
+    loading,
+    error,
+    refetch,
+    addOptimisticFolder,
+    replaceOptimisticFolder,
+    removeOptimisticFolder,
+  ]);
 
   return (
     <FolderExplorerContext.Provider value={contextValue}>

--- a/package.json
+++ b/package.json
@@ -51,8 +51,8 @@
     "@babel/core": "^7.25.2",
     "@types/react": "~19.0.10",
     "babel-plugin-module-resolver": "^5.0.2",
-    "fake-indexeddb": "^6.1.0",
     "eslint": "^8.57.0",
+    "fake-indexeddb": "^6.1.0",
     "ts-node": "^10.9.2",
     "typescript": "~5.8.3"
   }


### PR DESCRIPTION
## Summary
- memoize FolderExplorerContext value to keep object stable across renders
- import useMemo hook
- maintain test script after cleaning up

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a73c43924832bb541d03064cb2631