### PR TITLE
refactor: centralize unique id generation

### DIFF
--- a/data/recordingsStore.ts
+++ b/data/recordingsStore.ts
@@ -6,6 +6,7 @@ import { StoreEvent } from '@/types/store';
 import { AudioStorageService } from '@/services/audioStorage';
 import { FolderService } from '@/services/folderService';
 import { StorageService } from '@/services/storageService';
+import { generateUniqueId } from '@/utils/id';
 
 // Storage key
 const TAGS_KEY = 'rg.tags.v1';
@@ -79,11 +80,6 @@ function initSyncChannel(): void {
  * when tearing down or disabling the feature.
  */
 export class RecordingsStore {
-  // Utility functions
-  static generateUniqueId(): string {
-    return Date.now().toString() + '_' + Math.random().toString(36).substring(2, 15);
-  }
-
   /**
    * Explicitly initialize cross-tab synchronization. Should be called when the
    * application mounts if cross-tab syncing is desired.
@@ -222,7 +218,7 @@ export class RecordingsStore {
 
       const colors = ['#f4ad3d', '#3B82F6', '#10B981', '#EF4444', '#8B5CF6', '#F59E0B', '#06B6D4', '#EC4899'];
       const newTag: Tag = {
-        id: this.generateUniqueId(),
+        id: generateUniqueId(),
         name: trimmedName,
         createdAt: Date.now(),
         color: colors[Math.floor(Math.random() * colors.length)],

--- a/services/audioStorage.ts
+++ b/services/audioStorage.ts
@@ -3,6 +3,7 @@ import { Platform } from 'react-native';
 import { AudioFile, AudioFileMetadata } from '@/types/audio';
 import { StorageService } from './storageService';
 import logger from '@/utils/logger';
+import { generateUniqueId } from '@/utils/id';
 
 const STORAGE_KEY = 'audio_files';
 const AUDIO_DIR = `${FileSystem.documentDirectory}RecorderGearApp/AudioFiles/`;
@@ -54,7 +55,7 @@ export class AudioStorageService {
   static async saveAudioFile(fileUri: string, fileName: string, fileSize: number, mimeType?: string): Promise<AudioFile> {
     await this.initializeStorage();
     
-    const fileId = this.generateUniqueId();
+    const fileId = generateUniqueId();
     const fileExtension = fileName.split('.').pop() || 'mp3';
     const sanitizedFileName = fileName.replace(/[^a-zA-Z0-9.-]/g, '_');
     
@@ -179,9 +180,6 @@ export class AudioStorageService {
     });
   }
 
-  private static generateUniqueId(): string {
-    return Date.now().toString() + '_' + Math.random().toString(36).substring(2, 15);
-  }
 
   static async checkForDuplicate(fileName: string, fileSize: number): Promise<boolean> {
     try {

--- a/services/folderService.ts
+++ b/services/folderService.ts
@@ -3,6 +3,7 @@ import { StorageService } from './storageService';
 import { AudioStorageService } from './audioStorage';
 import { RecordingsStore } from '@/data/recordingsStore';
 import logger from '@/utils/logger';
+import { generateUniqueId } from '@/utils/id';
 
 // Unified storage key for all folder operations
 const UNIFIED_STORAGE_KEY = 'rg.folders.v1';
@@ -30,9 +31,6 @@ export class FolderService {
     }
   }
 
-  static generateUniqueId(): string {
-    return Date.now().toString() + '_' + Math.random().toString(36).substring(2, 15);
-  }
 
   private static generateUniqueFolderName(baseName: string, existingNames: Set<string>): string {
     let counter = 2;
@@ -95,7 +93,7 @@ export class FolderService {
         // Check for name collision
         if (seenNamesInFinal.has(oldFolder.name.toLowerCase())) {
           const uniqueName = this.generateUniqueFolderName(oldFolder.name, seenNamesInFinal);
-          const newId = this.generateUniqueId();
+          const newId = generateUniqueId();
           
           logger.log('🔄 Resolving name collision:', {
             originalName: oldFolder.name,
@@ -252,7 +250,7 @@ export class FolderService {
       }
 
       const newFolder: Folder = {
-        id: this.generateUniqueId(),
+        id: generateUniqueId(),
         name: trimmedName,
         parentId: parentId || null,
         createdAt: Date.now(),

--- a/services/tagService.ts
+++ b/services/tagService.ts
@@ -1,6 +1,7 @@
 import { Tag } from '@/types/tag';
 import { StorageService } from './storageService';
 import logger from '@/utils/logger';
+import { generateUniqueId } from '@/utils/id';
 
 export class TagService {
   private static readonly STORAGE_KEY = 'tags';
@@ -19,9 +20,6 @@ export class TagService {
     '#6366F1', // Indigo
   ];
 
-  static generateUniqueId(): string {
-    return Date.now().toString() + '_' + Math.random().toString(36).substring(2, 15);
-  }
 
   static getRandomColor(): string {
     return this.TAG_COLORS[Math.floor(Math.random() * this.TAG_COLORS.length)];
@@ -59,7 +57,7 @@ export class TagService {
       }
 
       const newTag: Tag = {
-        id: this.generateUniqueId(),
+        id: generateUniqueId(),
         name: trimmedName,
         createdAt: Date.now(),
         color: this.getRandomColor(),

--- a/utils/id.ts
+++ b/utils/id.ts
@@ -1,0 +1,3 @@
+export function generateUniqueId(): string {
+  return Date.now().toString() + '_' + Math.random().toString(36).substring(2, 15);
+}


### PR DESCRIPTION
## Summary
- add shared `generateUniqueId` utility
- refactor audio storage, folder, tag and recordings services to use shared ID generator

## Testing
- `npm test`
- `npm run lint` *(fails: Cannot read config file .eslintrc.json)*

------
https://chatgpt.com/codex/tasks/task_e_689a73c72d3c832ba8b93e5448cdc766